### PR TITLE
chore: expand .gitignore to cover .claude/, .omc/, .env, editor temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,20 @@ dist
 *.log
 .DS_Store
 
+# Editor temp files
+.idea/
+.vscode/
+*.swp
+
+# Environment / secrets (do not commit)
+.env
+.env.local
+.env.*.local
+
+# Agent tooling local artefacts
+.claude/
+.omc/
+
 # F-002 pipeline intermediate artifacts
 pipelines/data/
 pipelines/node_modules/


### PR DESCRIPTION
Closes #18

## Summary
- Adds eight `.gitignore` entries for Claude Code / oh-my-claudecode / dotenv / editor temp-file artefacts that previously surfaced as untracked and risked accidental staging.
- Purely additive — no existing rule changed; no tracked file removed.

## Changelog

### Changed
- `.gitignore`: added rules for `.claude/`, `.omc/`, `.env`, `.env.local`, `.env.*.local`, `.idea/`, `.vscode/`, `*.swp`. Existing entries (Node / build / F-002 pipeline) preserved.

## Verification

```bash
git check-ignore -v .claude/CLAUDE.md .env
# .gitignore:18:.claude/  .claude/CLAUDE.md
# .gitignore:13:.env      .env
```

`git status` on a clean checkout with these artefacts populated locally now shows them as ignored, not untracked. Verified locally before push.

## Why now

F-001 + F-002 PRs landed; #15 / #16 / #10 / #11 / #13 / #12 will be opened by people running Claude Code / OMC. Locking down the leak vector before merge volume picks up — exactly the timing called out in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
