### PR TITLE
feat(telemetry): pre/post Likert survey + telemetry (F-007)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,60 @@
 # van-der-view
+
+WebXR protein structure viewer for educational VR experiences (Quest 3).
+
+## Quick Start
+
+```bash
+npm install
+npm run dev          # Vite frontend on :5173 (HTTPS for WebXR)
+```
+
+## Telemetry Server
+
+Survey responses are collected via a separate Express + SQLite backend.
+
+```bash
+# Terminal 1: start the telemetry API
+npm run server       # Express on :3001
+
+# Terminal 2: start the Vite frontend (proxies /api → :3001)
+npm run dev
+
+# Or both at once:
+npm run dev:all
+```
+
+The Vite dev server proxies `/api` requests to `http://localhost:3001` automatically.
+
+### Endpoints
+
+- `POST /api/telemetry` — submit survey responses (array of objects)
+- `GET /api/telemetry` — retrieve all stored responses
+
+### Database
+
+Responses are stored in `data/telemetry.db` (SQLite, git-ignored).
+Override the path with `VDV_DB_PATH` environment variable.
+
+## Effect-Size Analysis
+
+After collecting survey data, compute Cohen's d per comparable pre/post Likert item:
+
+```bash
+npm run effect-size
+# Output: CSV with columns item_id, pre_mean, post_mean, mean_diff, pooled_sd, cohens_d, n_pre, n_post
+```
+
+The script reads from `data/telemetry.db` by default. Pass a custom path as an argument:
+
+```bash
+node scripts/effect-size.mjs path/to/other.db
+```
+
+## Survey Flow
+
+1. **Pre-survey** (4 Likert questions) — shown before the VR experience begins
+2. **VR experience** — 3D scene with grab/teleport interactions
+3. **Post-survey** (5 Likert + 1 free-text) — triggered by the "Finish / Take Post Survey" button
+
+Pre/post responses are linked by a session UUID generated on page load.


### PR DESCRIPTION
## Summary

Implements [F-007] Pre/post Likert survey + telemetry system (Closes #12).

- Pre-survey with 4 Likert questions (7-point scale, Sung et al. 2020 style)
- Post-survey with 6 questions (4 Likert + 1 PyMOL comparison + 1 free-text)
- Full-screen DOM overlay UI for survey display
- Express endpoint `POST /api/telemetry` with validation
- SQLite persistence (`data/telemetry.db`) with all required columns
- `scripts/effect-size.mjs` computes Cohen's d per comparable pre/post item, outputs CSV
- README docs for telemetry server and effect-size usage

## Test plan

- [x] `npm install` succeeds with new dependencies (express, better-sqlite3, cors)
- [x] `npm run build` passes (Vite build)
- [x] `npm run server` starts Express on :3001
- [x] `POST /api/telemetry` accepts valid payloads, rejects invalid ones
- [x] `GET /api/telemetry` returns stored rows with all 8 columns
- [x] `npm run effect-size` outputs CSV with correct Cohen's d calculation
- [x] Frontend survey flow: pre-survey → experience → finish button → post-survey

## Changelog

- Added: pre/post Likert survey UI (DOM overlay)
- Added: Express + SQLite telemetry backend (`POST /api/telemetry`)
- Added: `scripts/effect-size.mjs` for Cohen's d analysis
- Added: README documentation for telemetry and effect-size usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)