### PR TITLE
fix(tutorial): completable alignment, click-only portals, closer spawn

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -153,6 +153,14 @@ function loadScene(sceneIdOrClass) {
 
   grabbables = activeScene.getGrabbables();
   if (activeScene.enableSkipShortcut) activeScene.enableSkipShortcut();
+
+  // Apply the scene's preferred spawn (player room-origin + desktop camera).
+  // VR overrides camera each frame from headset pose, so player.position is
+  // what positions the user in world; camera.position only matters in 2D.
+  if (activeScene.spawn) {
+    if (activeScene.spawn.player) player.position.fromArray(activeScene.spawn.player);
+    if (activeScene.spawn.camera) camera.position.fromArray(activeScene.spawn.camera);
+  }
 }
 
 function transitionToScene(sceneId) {
@@ -173,9 +181,6 @@ function transitionToHub() {
   _fadeOut(300).then(() => {
     loadScene(GameHubScene);
     _syncHubProgress();
-    // Reset player to hub entry point
-    player.position.set(0, 0, 0);
-    camera.position.set(0, 1.6, 3);
     renderer.render(scene, camera);
     _fadeIn(300).then(() => {
       transitioning = false;

--- a/src/scenes/GameHubScene.js
+++ b/src/scenes/GameHubScene.js
@@ -38,6 +38,7 @@ export default class GameHubScene {
     this._buildPortals();
     this._buildProgressDisplay();
     this._buildPrompt();
+    this.spawn = { player: [0, 0, 0], camera: [0, 1.6, 3] };
   }
 
   update(dt, controllers) {
@@ -294,7 +295,7 @@ export default class GameHubScene {
     sprite.position.set(0, 2.5, -1.0);
     this._add(sprite);
     this.promptSprite = sprite;
-    this._setPrompt('Walk into a portal to enter');
+    this._setPrompt('Trigger or click a portal to enter');
   }
 
   _setPrompt(text) {
@@ -332,23 +333,8 @@ export default class GameHubScene {
   // ---- portal activation --------------------------------------------------
 
   _checkPortalActivation(controllers) {
-    // Check if player walks into any unlocked portal
-    const playerPos = new THREE.Vector3();
-    this.ctx.player.getWorldPosition(playerPos);
-
-    for (const p of this.portals) {
-      if (!this.isUnlocked(p.def.id)) continue;
-
-      const portalPos = new THREE.Vector3();
-      p.group.getWorldPosition(portalPos);
-      portalPos.y = playerPos.y; // horizontal distance only
-
-      const dist = playerPos.distanceTo(portalPos);
-      if (dist < 0.6) {
-        if (this.onSelectPortal) this.onSelectPortal(p.def.id);
-        return;
-      }
-    }
+    // Portals are click-only — walk-through proximity-trigger removed because
+    // accidental crossings during locomotion fired transitions unintentionally.
 
     // VR: point controller at portal frame + press trigger
     // Track select state to detect fresh presses (not held)

--- a/src/scenes/TutorialScene.js
+++ b/src/scenes/TutorialScene.js
@@ -61,6 +61,9 @@ export default class TutorialScene {
     this._buildArrow();
     this._buildFloorDecor();
     this._enterState(STATES.INTRO);
+    // Spawn ~1m from the pocket (which sits at z=-0.6) so the user can
+    // interact without walking.
+    this.spawn = { player: [0, 0, 0], camera: [0, 1.6, 0.4] };
   }
 
   update(dt, controllers) {
@@ -154,13 +157,15 @@ export default class TutorialScene {
     const center = new THREE.Mesh(cGeo, cMat);
     group.add(center);
 
-    // 3 arms pointing in the same directions as the pocket markers
-    const armLength = 0.10;
+    // Arm-tip geometry must coincide with the H-bond marker positions in
+    // _buildPocket when the ligand is centered + aligned, otherwise the
+    // alignment-completion check (SNAP_DIST + ALIGN_THRESHOLD) is unreachable.
+    const yOff = POCKET_RADIUS * 0.35;
+    const rAtY = Math.sqrt(Math.max(0.001, POCKET_RADIUS * POCKET_RADIUS - yOff * yOff)) * 0.8;
+    const armLength = Math.sqrt(rAtY * rAtY + yOff * yOff);
     const armPositions = []; // local offsets for the arm tips
     for (let i = 0; i < 3; i++) {
       const angle = (i / 3) * Math.PI * 2 - Math.PI / 2;
-      const yOff = 0.035;
-      const rAtY = 0.08;
       const dx = Math.cos(angle) * rAtY;
       const dy = yOff;
       const dz = Math.sin(angle) * rAtY;


### PR DESCRIPTION
Closes #29

## What & why

Three of the four items from #29:

1. **Click-only hub portals.** `GameHubScene._checkPortalActivation()` had three entry paths — walk-through proximity, VR trigger raycast, desktop click. The walk-through path fired transitions accidentally during locomotion. Dropped it; the existing trigger/click paths already implement click-to-enter. Prompt updated from "Walk into a portal to enter" to "Trigger or click a portal to enter".

2. **Tutorial is completable.** Pocket H-bond markers are placed using `POCKET_RADIUS`-derived geometry (`yOff = R*0.35`, `rAtY = sqrt(R² - yOff²) * 0.8`). The ligand arms were hard-coded at `yOff = 0.035`, `rAtY = 0.08` — about half the required radial distance — so even a perfectly centered + oriented ligand left every arm-marker pair >`SNAP_DIST (0.10)` apart, with `_alignmentScore()` saturating to 0 past 0.2m. Reworked `_buildLigand` to derive the same `yOff`/`rAtY` from `POCKET_RADIUS`, plus an `armLength = sqrt(rAtY² + yOff²)` so the bond cylinders stay in scale with the new arm tips.

3. **Closer spawn in tutorial.** Added an `activeScene.spawn = { player: [...], camera: [...] }` convention applied by `loadScene()` after `init()`. Tutorial declares `camera: [0, 1.6, 0.4]` (~1.17m from the pocket at (0, 1.0, -0.6)) so the user starts within reach. `GameHubScene` declares the spawn the old manual reset in `transitionToHub()` used to set, so that duplicated reset is removed in favor of the unified path.

### Item 2 deferred

Item 2 from #29 ("X-axis rotation feels reversed") is intentionally not in this PR. Object rotation in VR comes via `controller.attach(obj)` (`src/main.js:289`) — quaternion inheritance with no explicit axis-delta to flip — and I couldn't pin the reversal without headset-side reproduction. Best to leave #29 open with item 2 unresolved (or split it to a follow-up issue) rather than guess and risk inverting a working axis.

## Testing

- `npm run build` — clean (no new warnings; the >500kB chunk warning is preexisting).
- Did not run a headset session — items 1, 3, 4 are deterministic geometry/state changes verifiable from the diff. Item 2 is the only one that needed headset repro and that's why it's deferred.

Suggested in-headset checks for the reviewer:
- Hub: walking through where a portal sits should not transition; trigger-clicking or mouse-clicking it should.
- Tutorial: positioning the ligand in the pocket with reasonable orientation should now drive the state machine through `WAIT_SNAP → SNAPPED → COMPLETE`.
- Tutorial entry: the user should appear near the pocket, not the far side of the room.

## Changelog

Fixed: tutorial alignment is now completable (ligand arm geometry matched to pocket H-bond markers), hub portals are click-only (walk-through trigger removed), and the tutorial spawns the user near the pocket instead of ~3.6m away.