### PR TITLE
feat(hub): replace 3D portals with click-to-enter menu, remove teleport

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -70,6 +70,7 @@ const controllerModelFactory = new XRControllerModelFactory();
 const handModelFactory = new XRHandModelFactory();
 
 const tempMatrix = new THREE.Matrix4();
+const raycaster = new THREE.Raycaster();
 
 // ---- Scene transition system -----------------------------------------------
 
@@ -235,7 +236,6 @@ function _syncHubProgress() {
 
 function buildController(index) {
   const controller = renderer.xr.getController(index);
-  controller.userData.teleporting = false;
   controller.userData.held = null;
 
   const grip = renderer.xr.getControllerGrip(index);
@@ -254,15 +254,8 @@ function buildController(index) {
   line.scale.z = 5;
   controller.add(line);
 
-  controller.addEventListener('squeezestart', () => { controller.userData.teleporting = true; });
-  controller.addEventListener('squeezeend', () => {
-    controller.userData.teleporting = false;
-    if (teleportMarker.visible) {
-      player.position.x = teleportMarker.position.x;
-      player.position.z = teleportMarker.position.z;
-      teleportMarker.visible = false;
-    }
-  });
+  controller.addEventListener('selectstart', () => onSelectStart(controller));
+  controller.addEventListener('selectend', () => onSelectEnd(controller));
 
   player.add(controller);
   return controller;
@@ -296,34 +289,7 @@ function onSelectEnd(controller) {
 const controller0 = buildController(0);
 const controller1 = buildController(1);
 
-controller0.addEventListener('selectstart', () => onSelectStart(controller0));
-controller0.addEventListener('selectend', () => onSelectEnd(controller0));
-controller1.addEventListener('selectstart', () => onSelectStart(controller1));
-controller1.addEventListener('selectend', () => onSelectEnd(controller1));
-
-const raycaster = new THREE.Raycaster();
-const teleportMarker = new THREE.Mesh(
-  new THREE.RingGeometry(0.18, 0.22, 32).rotateX(-Math.PI / 2),
-  new THREE.MeshBasicMaterial({ color: 0x06d6a0, transparent: true, opacity: 0.85 })
-);
-teleportMarker.visible = false;
-scene.add(teleportMarker);
-
-function updateTeleport(controller) {
-  if (!controller.userData.teleporting) return;
-  tempMatrix.identity().extractRotation(controller.matrixWorld);
-  raycaster.ray.origin.setFromMatrixPosition(controller.matrixWorld);
-  raycaster.ray.direction.set(0, 0, -1).applyMatrix4(tempMatrix);
-  const hit = raycaster.intersectObject(floor, false)[0];
-  if (hit) {
-    teleportMarker.position.copy(hit.point);
-    teleportMarker.visible = true;
-  } else {
-    teleportMarker.visible = false;
-  }
-}
-
-function handleThumbstickTeleport() {
+function handleThumbstickLocomotion() {
   const session = renderer.xr.getSession();
   if (!session) return;
   for (const source of session.inputSources) {
@@ -443,9 +409,7 @@ renderer.setAnimationLoop((time) => {
   const dt = lastTime ? time - lastTime : 16;
   lastTime = time;
 
-  updateTeleport(controller0);
-  updateTeleport(controller1);
-  handleThumbstickTeleport();
+  handleThumbstickLocomotion();
   handleDesktopFallback(dt);
 
   if (activeScene && !transitioning) {

--- a/src/main.js
+++ b/src/main.js
@@ -275,7 +275,14 @@ function onSelectStart(controller) {
     if (obj.userData.grabbable) {
       controller.attach(obj);
       controller.userData.held = obj;
+      return;
     }
+  }
+
+  // No grab hit — let the active scene treat the trigger as a click
+  // (e.g. hub menu raycast). Mirrors the desktop mouse-click path.
+  if (activeScene && activeScene._onControllerClick) {
+    activeScene._onControllerClick(controller);
   }
 }
 

--- a/src/scenes/GameHubScene.js
+++ b/src/scenes/GameHubScene.js
@@ -52,10 +52,13 @@ export default class GameHubScene {
     // and init (e.g. transitionToHub right after a level's onComplete).
     this._loadProgress();
     this._buildMenu();
+    this._buildTipDots();
+    this.hoveredRow = -1;
     this.spawn = { player: [0, 0, 0], camera: [0, 1.6, 1.0] };
   }
 
   update(dt, controllers) {
+    this._updateHover(controllers);
     this._checkMenuActivation();
   }
 
@@ -141,12 +144,25 @@ export default class GameHubScene {
     const def = LEVEL_DEFS[i];
     const unlocked = this.isUnlocked(def.id);
     const completed = this.progress[def.id];
+    const hovered = i === this.hoveredRow;
     const yTop = TITLE_BAND_H + i * ROW_HEIGHT;
     const yMid = yTop + ROW_HEIGHT / 2;
 
-    // Row background tint
-    ctx.fillStyle = unlocked ? 'rgba(60, 80, 140, 0.18)' : 'rgba(60, 60, 80, 0.08)';
+    // Row background tint — brighter when the controller ray is on this row.
+    let bg;
+    if (hovered && unlocked)      bg = 'rgba(80, 150, 240, 0.45)';
+    else if (hovered && !unlocked) bg = 'rgba(120, 100, 100, 0.30)';
+    else if (unlocked)             bg = 'rgba(60, 80, 140, 0.18)';
+    else                           bg = 'rgba(60, 60, 80, 0.08)';
+    ctx.fillStyle = bg;
     ctx.fillRect(20, yTop + 8, CANVAS_W - 40, ROW_HEIGHT - 16);
+
+    // Hover outline
+    if (hovered) {
+      ctx.strokeStyle = unlocked ? '#3aa6ff' : '#776688';
+      ctx.lineWidth = 3;
+      ctx.strokeRect(20, yTop + 8, CANVAS_W - 40, ROW_HEIGHT - 16);
+    }
 
     // Status icon
     let iconText, iconColor;
@@ -215,6 +231,59 @@ export default class GameHubScene {
         this._activateRow(this._hitTestRow(hits[0].uv));
       }
       this._desktopClick = null;
+    }
+  }
+
+  // ---- hover feedback (per-frame raycast) ---------------------------------
+
+  // Without a visible aim indicator, VR users have no way to know whether
+  // they're pointing at the menu before pulling the trigger. We raycast each
+  // controller every frame, snap a tip dot to the hit point, and highlight
+  // the hovered row in the canvas.
+  _buildTipDots() {
+    const dotGeo = new THREE.SphereGeometry(0.012, 12, 12);
+    this.tipDots = [];
+    for (let i = 0; i < 2; i++) {
+      const mat = new THREE.MeshBasicMaterial({ color: 0x06d6a0, depthTest: false });
+      const dot = new THREE.Mesh(dotGeo, mat);
+      dot.visible = false;
+      dot.renderOrder = 1000;
+      this._add(dot);
+      this.tipDots.push(dot);
+    }
+  }
+
+  _updateHover(controllers) {
+    const session = this.ctx.renderer.xr.getSession();
+    let newHover = -1;
+
+    for (let i = 0; i < 2; i++) {
+      const ctrl = controllers[i];
+      const dot = this.tipDots[i];
+      if (!session || !ctrl) {
+        dot.visible = false;
+        continue;
+      }
+
+      const tempMat = new THREE.Matrix4().extractRotation(ctrl.matrixWorld);
+      const rc = new THREE.Raycaster();
+      rc.ray.origin.setFromMatrixPosition(ctrl.matrixWorld);
+      rc.ray.direction.set(0, 0, -1).applyMatrix4(tempMat);
+      const hits = rc.intersectObject(this.menuPlane, false);
+
+      if (hits.length > 0 && hits[0].uv) {
+        dot.position.copy(hits[0].point);
+        dot.visible = true;
+        const row = this._hitTestRow(hits[0].uv);
+        if (row >= 0 && newHover < 0) newHover = row;
+      } else {
+        dot.visible = false;
+      }
+    }
+
+    if (newHover !== this.hoveredRow) {
+      this.hoveredRow = newHover;
+      this._renderMenu();
     }
   }
 

--- a/src/scenes/GameHubScene.js
+++ b/src/scenes/GameHubScene.js
@@ -1,30 +1,41 @@
 import * as THREE from 'three';
 
 // ---------------------------------------------------------------------------
-// F-004a Game Hub — Portal navigation + scene transition system
-// Acceptance: hub with portals, gating, progress display, <1s transitions
+// Game Hub — flat level-select menu (no 3D portals, no teleport).
+// Renders a clickable canvas-on-plane in front of the user. Each row is
+// driven by the existing progress / isUnlocked machinery, so completing
+// level N visually unlocks N+1 the next time the user is in the hub.
 // ---------------------------------------------------------------------------
 
-const PORTAL_DEFS = [
-  { id: 'tutorial', label: 'Tutorial', color: 0x06d6a0, angle: -0.45 },
-  { id: 'l1',       label: 'Level 1',  color: 0x3aa6ff, angle: -0.15 },
-  { id: 'l2',       label: 'Level 2',  color: 0xffd166, angle:  0.15 },
-  { id: 'l3',       label: 'Level 3',  color: 0xff6f91, angle:  0.45 },
+const LEVEL_DEFS = [
+  { id: 'tutorial', label: 'Tutorial',              color: '#06d6a0' },
+  { id: 'l1',       label: 'Level 1 — COX-2 Dock',  color: '#3aa6ff' },
+  { id: 'l2',       label: 'Level 2 — Rank NSAIDs', color: '#ffd166' },
+  { id: 'l3',       label: 'Level 3 — Selectivity', color: '#ff6f91' },
 ];
 
-// Unlock order: tutorial always open, l1 after tutorial, l2 after l1, l3 after l2
 const UNLOCK_ORDER = ['tutorial', 'l1', 'l2', 'l3'];
+
+const CANVAS_W = 768;
+const CANVAS_H = 512;
+const TITLE_BAND_H = 96;
+const ROW_HEIGHT = (CANVAS_H - TITLE_BAND_H) / LEVEL_DEFS.length;
+
+const PLANE_W = 1.2;
+const PLANE_H = 0.8;
+const PLANE_POS = [0, 1.5, -1.0];
 
 export default class GameHubScene {
   constructor(ctx) {
     this.ctx = ctx; // { scene, player, renderer, camera }
     this.objects = [];
     this.grabbables = [];
-    this.portals = [];
-    this.onSelectPortal = null; // callback(sceneId) for scene manager
+    this.onSelectPortal = null;
+    // Initialize to null (not undefined) so main.js's mousedown handler
+    // forwards desktop clicks: it gates on `_desktopClick !== undefined`.
+    this._desktopClick = null;
     this.progress = { tutorial: false, l1: false, l2: false, l3: false };
 
-    // Restore progress from sessionStorage
     try {
       const saved = sessionStorage.getItem('vdv-progress');
       if (saved) this.progress = JSON.parse(saved);
@@ -34,16 +45,12 @@ export default class GameHubScene {
   // ---- public lifecycle ---------------------------------------------------
 
   init() {
-    this._buildEnvironment();
-    this._buildPortals();
-    this._buildProgressDisplay();
-    this._buildPrompt();
-    this.spawn = { player: [0, 0, 0], camera: [0, 1.6, 3] };
+    this._buildMenu();
+    this.spawn = { player: [0, 0, 0], camera: [0, 1.6, 1.0] };
   }
 
   update(dt, controllers) {
-    this._updatePortalAnimations(dt);
-    this._checkPortalActivation(controllers);
+    this._checkMenuActivation(controllers);
   }
 
   getGrabbables() { return this.grabbables; }
@@ -51,294 +58,137 @@ export default class GameHubScene {
   markComplete(sceneId) {
     this.progress[sceneId] = true;
     try { sessionStorage.setItem('vdv-progress', JSON.stringify(this.progress)); } catch {}
-    this._refreshPortalStates();
-    this._updateProgressDisplay();
+    this._renderMenu();
   }
 
   isUnlocked(sceneId) {
     const idx = UNLOCK_ORDER.indexOf(sceneId);
-    if (idx <= 0) return true; // tutorial always open
+    if (idx <= 0) return true;
     return this.progress[UNLOCK_ORDER[idx - 1]];
   }
 
-  // ---- environment --------------------------------------------------------
+  // ---- menu construction --------------------------------------------------
 
-  _buildEnvironment() {
-    // Central platform
-    const platGeo = new THREE.CylinderGeometry(2.0, 2.2, 0.08, 48);
-    const platMat = new THREE.MeshStandardMaterial({ color: 0x14142a, roughness: 0.7, metalness: 0.2 });
-    const platform = new THREE.Mesh(platGeo, platMat);
-    platform.position.set(0, 0.04, -1.0);
-    this._add(platform);
-
-    // Subtle grid on platform
-    const gridGeo = new THREE.RingGeometry(0.3, 1.9, 48);
-    const gridMat = new THREE.MeshBasicMaterial({ color: 0x222244, transparent: true, opacity: 0.3, side: THREE.DoubleSide });
-    const gridRing = new THREE.Mesh(gridGeo, gridMat);
-    gridRing.rotation.x = -Math.PI / 2;
-    gridRing.position.set(0, 0.09, -1.0);
-    this._add(gridRing);
-  }
-
-  // ---- portals ------------------------------------------------------------
-
-  _buildPortals() {
-    this.portals = [];
-    const hubCenter = new THREE.Vector3(0, 1.0, -1.0);
-    const radius = 1.6;
-
-    for (const def of PORTAL_DEFS) {
-      const group = new THREE.Group();
-      group.userData.portalId = def.id;
-
-      const x = hubCenter.x + Math.sin(def.angle) * radius;
-      const z = hubCenter.z - Math.cos(def.angle) * radius;
-      group.position.set(x, 0, z);
-
-      // Face toward hub center
-      group.lookAt(hubCenter.x, 0, hubCenter.z);
-
-      // Portal frame (torus)
-      const frameGeo = new THREE.TorusGeometry(0.4, 0.04, 16, 48);
-      const frameMat = new THREE.MeshStandardMaterial({
-        color: def.color,
-        emissive: def.color,
-        emissiveIntensity: 0.4,
-        roughness: 0.3,
-        metalness: 0.5,
-      });
-      const frame = new THREE.Mesh(frameGeo, frameMat);
-      frame.position.y = 1.2;
-      group.add(frame);
-
-      // Inner glow plane
-      const innerGeo = new THREE.CircleGeometry(0.36, 32);
-      const innerMat = new THREE.MeshBasicMaterial({
-        color: def.color,
-        transparent: true,
-        opacity: 0.15,
-        side: THREE.DoubleSide,
-      });
-      const inner = new THREE.Mesh(innerGeo, innerMat);
-      inner.position.y = 1.2;
-      inner.position.z = 0.01;
-      group.add(inner);
-
-      // Lock icon (X shape) — shown when locked
-      const lockGroup = new THREE.Group();
-      lockGroup.position.y = 1.2;
-      lockGroup.visible = false;
-      const lockMat = new THREE.MeshBasicMaterial({ color: 0x555577 });
-      const bar1 = new THREE.Mesh(new THREE.BoxGeometry(0.3, 0.04, 0.02), lockMat);
-      bar1.rotation.z = Math.PI / 4;
-      lockGroup.add(bar1);
-      const bar2 = new THREE.Mesh(new THREE.BoxGeometry(0.3, 0.04, 0.02), lockMat);
-      bar2.rotation.z = -Math.PI / 4;
-      lockGroup.add(bar2);
-      group.add(lockGroup);
-
-      // Label sprite
-      const label = this._createLabelSprite(def.label, def.color);
-      label.position.y = 1.75;
-      group.add(label);
-
-      // Floor marker ring
-      const markerGeo = new THREE.RingGeometry(0.35, 0.38, 32);
-      const markerMat = new THREE.MeshBasicMaterial({
-        color: def.color,
-        transparent: true,
-        opacity: 0.4,
-        side: THREE.DoubleSide,
-      });
-      const marker = new THREE.Mesh(markerGeo, markerMat);
-      marker.rotation.x = -Math.PI / 2;
-      marker.position.y = 0.01;
-      group.add(marker);
-
-      this._add(group);
-      this.portals.push({
-        group,
-        frame,
-        inner,
-        lockGroup,
-        label,
-        marker,
-        frameMat,
-        innerMat,
-        markerMat,
-        def,
-      });
-    }
-
-    this._refreshPortalStates();
-  }
-
-  _refreshPortalStates() {
-    for (const p of this.portals) {
-      const unlocked = this.isUnlocked(p.def.id);
-      const completed = this.progress[p.def.id];
-
-      // Visual state
-      p.lockGroup.visible = !unlocked;
-      p.inner.visible = unlocked;
-
-      if (!unlocked) {
-        p.frameMat.color.setHex(0x333355);
-        p.frameMat.emissive.setHex(0x333355);
-        p.frameMat.emissiveIntensity = 0.1;
-        p.innerMat.color.setHex(0x333355);
-        p.innerMat.opacity = 0.05;
-        p.markerMat.color.setHex(0x333355);
-        p.markerMat.opacity = 0.15;
-      } else if (completed) {
-        p.frameMat.emissiveIntensity = 0.6;
-        p.innerMat.opacity = 0.35;
-        p.markerMat.opacity = 0.7;
-      } else {
-        p.frameMat.color.setHex(p.def.color);
-        p.frameMat.emissive.setHex(p.def.color);
-        p.frameMat.emissiveIntensity = 0.4;
-        p.innerMat.color.setHex(p.def.color);
-        p.innerMat.opacity = 0.15;
-        p.markerMat.color.setHex(p.def.color);
-        p.markerMat.opacity = 0.4;
-      }
-    }
-  }
-
-  // ---- progress display ---------------------------------------------------
-
-  _buildProgressDisplay() {
+  _buildMenu() {
     const canvas = document.createElement('canvas');
-    canvas.width = 512;
-    canvas.height = 256;
-    this.progressCanvas = canvas;
-    this.progressCtx = canvas.getContext('2d');
+    canvas.width = CANVAS_W;
+    canvas.height = CANVAS_H;
+    this.menuCanvas = canvas;
+    this.menuCtx = canvas.getContext('2d');
 
-    const texture = new THREE.CanvasTexture(canvas);
-    texture.minFilter = THREE.LinearFilter;
-    const mat = new THREE.SpriteMaterial({ map: texture, transparent: true, depthTest: false });
-    const sprite = new THREE.Sprite(mat);
-    sprite.scale.set(0.8, 0.4, 1);
-    sprite.position.set(0, 2.0, -1.0);
-    this._add(sprite);
-    this.progressSprite = sprite;
+    const tex = new THREE.CanvasTexture(canvas);
+    tex.minFilter = THREE.LinearFilter;
+    this.menuTexture = tex;
 
-    this._updateProgressDisplay();
+    const geo = new THREE.PlaneGeometry(PLANE_W, PLANE_H);
+    const mat = new THREE.MeshBasicMaterial({ map: tex, transparent: true });
+    const plane = new THREE.Mesh(geo, mat);
+    plane.position.fromArray(PLANE_POS);
+    this.menuPlane = plane;
+    this._add(plane);
+
+    this._renderMenu();
   }
 
-  _updateProgressDisplay() {
-    const ctx = this.progressCtx;
-    const w = this.progressCanvas.width;
-    const h = this.progressCanvas.height;
-    ctx.clearRect(0, 0, w, h);
+  _renderMenu() {
+    const ctx = this.menuCtx;
+    ctx.clearRect(0, 0, CANVAS_W, CANVAS_H);
 
-    // Background
-    ctx.fillStyle = 'rgba(0,0,0,0.5)';
+    // Card background
+    ctx.fillStyle = 'rgba(10, 12, 32, 0.92)';
     ctx.beginPath();
-    ctx.roundRect(0, 0, w, h, 16);
+    ctx.roundRect(0, 0, CANVAS_W, CANVAS_H, 24);
     ctx.fill();
+
+    // Subtle border
+    ctx.strokeStyle = 'rgba(120, 140, 200, 0.35)';
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.roundRect(1, 1, CANVAS_W - 2, CANVAS_H - 2, 23);
+    ctx.stroke();
 
     // Title
-    ctx.fillStyle = '#06d6a0';
-    ctx.font = 'bold 32px system-ui, sans-serif';
-    ctx.textAlign = 'center';
-    ctx.fillText('Progress', w / 2, 40);
-
-    // Level status
-    const levels = [
-      { id: 'tutorial', label: 'Tutorial' },
-      { id: 'l1', label: 'Level 1 — COX-2 Dock' },
-      { id: 'l2', label: 'Level 2 — Rank NSAIDs' },
-      { id: 'l3', label: 'Level 3 — Selectivity' },
-    ];
-
-    ctx.font = '24px system-ui, sans-serif';
-    for (let i = 0; i < levels.length; i++) {
-      const y = 80 + i * 42;
-      const unlocked = this.isUnlocked(levels[i].id);
-      const completed = this.progress[levels[i].id];
-
-      if (completed) {
-        ctx.fillStyle = '#06d6a0';
-        ctx.fillText('✓', 30, y);
-      } else if (unlocked) {
-        ctx.fillStyle = '#3aa6ff';
-        ctx.fillText('►', 30, y);
-      } else {
-        ctx.fillStyle = '#555577';
-        ctx.fillText('✗', 30, y);
-      }
-
-      ctx.fillStyle = completed ? '#06d6a0' : unlocked ? '#ffffff' : '#555577';
-      ctx.textAlign = 'left';
-      ctx.fillText(levels[i].label, 60, y);
-    }
-
-    this.progressSprite.material.map.needsUpdate = true;
-  }
-
-  // ---- prompt -------------------------------------------------------------
-
-  _buildPrompt() {
-    const canvas = document.createElement('canvas');
-    canvas.width = 512;
-    canvas.height = 96;
-    this.promptCanvas = canvas;
-    this.promptCtx = canvas.getContext('2d');
-
-    const texture = new THREE.CanvasTexture(canvas);
-    texture.minFilter = THREE.LinearFilter;
-    const mat = new THREE.SpriteMaterial({ map: texture, transparent: true, depthTest: false });
-    const sprite = new THREE.Sprite(mat);
-    sprite.scale.set(0.7, 0.13, 1);
-    sprite.position.set(0, 2.5, -1.0);
-    this._add(sprite);
-    this.promptSprite = sprite;
-    this._setPrompt('Trigger or click a portal to enter');
-  }
-
-  _setPrompt(text) {
-    const ctx = this.promptCtx;
-    const w = this.promptCanvas.width;
-    const h = this.promptCanvas.height;
-    ctx.clearRect(0, 0, w, h);
-    ctx.fillStyle = 'rgba(0,0,0,0.6)';
-    ctx.beginPath();
-    ctx.roundRect(0, 0, w, h, 12);
-    ctx.fill();
     ctx.fillStyle = '#ffffff';
-    ctx.font = 'bold 24px system-ui, sans-serif';
+    ctx.font = 'bold 44px system-ui, sans-serif';
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
-    ctx.fillText(text, w / 2, h / 2, w - 20);
-    this.promptSprite.material.map.needsUpdate = true;
-  }
+    ctx.fillText('Select a Level', CANVAS_W / 2, TITLE_BAND_H / 2);
 
-  // ---- portal animations --------------------------------------------------
+    // Title underline
+    ctx.strokeStyle = 'rgba(120, 140, 200, 0.4)';
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(60, TITLE_BAND_H);
+    ctx.lineTo(CANVAS_W - 60, TITLE_BAND_H);
+    ctx.stroke();
 
-  _updatePortalAnimations(dt) {
-    const t = performance.now() * 0.001;
-    for (const p of this.portals) {
-      const unlocked = this.isUnlocked(p.def.id);
-      if (unlocked && !this.progress[p.def.id]) {
-        // Pulse unlocked but incomplete portals
-        const s = 1 + Math.sin(t * 2 + p.def.angle * 10) * 0.05;
-        p.frame.scale.setScalar(s);
-        p.innerMat.opacity = 0.15 + Math.sin(t * 3 + p.def.angle * 8) * 0.08;
-      }
+    // Rows
+    for (let i = 0; i < LEVEL_DEFS.length; i++) {
+      this._renderRow(i);
     }
+
+    this.menuTexture.needsUpdate = true;
   }
 
-  // ---- portal activation --------------------------------------------------
+  _renderRow(i) {
+    const ctx = this.menuCtx;
+    const def = LEVEL_DEFS[i];
+    const unlocked = this.isUnlocked(def.id);
+    const completed = this.progress[def.id];
+    const yTop = TITLE_BAND_H + i * ROW_HEIGHT;
+    const yMid = yTop + ROW_HEIGHT / 2;
 
-  _checkPortalActivation(controllers) {
-    // Portals are click-only — walk-through proximity-trigger removed because
-    // accidental crossings during locomotion fired transitions unintentionally.
+    // Row background tint
+    ctx.fillStyle = unlocked ? 'rgba(60, 80, 140, 0.18)' : 'rgba(60, 60, 80, 0.08)';
+    ctx.fillRect(20, yTop + 8, CANVAS_W - 40, ROW_HEIGHT - 16);
 
-    // VR: point controller at portal frame + press trigger
-    // Track select state to detect fresh presses (not held)
+    // Status icon
+    let iconText, iconColor;
+    if (completed)     { iconText = '✓'; iconColor = '#06d6a0'; }
+    else if (unlocked) { iconText = '►'; iconColor = '#3aa6ff'; }
+    else               { iconText = '✗'; iconColor = '#555577'; }
+    ctx.fillStyle = iconColor;
+    ctx.font = 'bold 40px system-ui, sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(iconText, 60, yMid);
+
+    // Label
+    ctx.fillStyle = unlocked ? def.color : '#666688';
+    ctx.font = unlocked ? 'bold 30px system-ui, sans-serif' : '30px system-ui, sans-serif';
+    ctx.textAlign = 'left';
+    ctx.fillText(def.label, 110, yMid);
+
+    // Status hint (right-aligned)
+    const hint = completed ? 'COMPLETE' : unlocked ? 'CLICK TO ENTER' : 'LOCKED';
+    ctx.fillStyle = completed ? '#06d6a0' : unlocked ? '#aaaacc' : '#555577';
+    ctx.font = '18px system-ui, sans-serif';
+    ctx.textAlign = 'right';
+    ctx.fillText(hint, CANVAS_W - 30, yMid);
+  }
+
+  // ---- input → row activation ---------------------------------------------
+
+  // PlaneGeometry uv: (0,0) bottom-left, (1,1) top-right. Canvas y is 0 at top, so flip.
+  _hitTestRow(uv) {
+    const canvasY = (1 - uv.y) * CANVAS_H;
+    if (canvasY < TITLE_BAND_H) return -1;
+    const idx = Math.floor((canvasY - TITLE_BAND_H) / ROW_HEIGHT);
+    if (idx < 0 || idx >= LEVEL_DEFS.length) return -1;
+    return idx;
+  }
+
+  _activateRow(idx) {
+    if (idx < 0) return;
+    const def = LEVEL_DEFS[idx];
+    if (!this.isUnlocked(def.id)) return;
+    if (this.onSelectPortal) this.onSelectPortal(def.id);
+  }
+
+  _checkMenuActivation(controllers) {
     if (this._prevSelect === undefined) this._prevSelect = [false, false];
+
+    // VR: trigger raycast against menu plane
     const session = this.ctx.renderer.xr.getSession();
     if (session) {
       let idx = 0;
@@ -348,21 +198,17 @@ export default class GameHubScene {
         const freshPress = pressed && !this._prevSelect[idx];
 
         if (freshPress) {
-          const rc = new THREE.Raycaster();
           const ctrl = controllers[idx];
           if (ctrl) {
             const tempMat = new THREE.Matrix4().extractRotation(ctrl.matrixWorld);
+            const rc = new THREE.Raycaster();
             rc.ray.origin.setFromMatrixPosition(ctrl.matrixWorld);
             rc.ray.direction.set(0, 0, -1).applyMatrix4(tempMat);
-
-            for (const p of this.portals) {
-              if (!this.isUnlocked(p.def.id)) continue;
-              const hits = rc.intersectObject(p.frame, false);
-              if (hits.length > 0) {
-                if (this.onSelectPortal) this.onSelectPortal(p.def.id);
-                this._prevSelect[idx] = pressed;
-                return;
-              }
+            const hits = rc.intersectObject(this.menuPlane, false);
+            if (hits.length > 0 && hits[0].uv) {
+              this._activateRow(this._hitTestRow(hits[0].uv));
+              this._prevSelect[idx] = pressed;
+              return;
             }
           }
         }
@@ -371,41 +217,19 @@ export default class GameHubScene {
       }
     }
 
-    // Desktop: click on portal frame
+    // Desktop: forwarded mouse click
     if (this._desktopClick) {
       const rc = new THREE.Raycaster();
       rc.setFromCamera(this._desktopClick, this.ctx.camera);
-      for (const p of this.portals) {
-        if (!this.isUnlocked(p.def.id)) continue;
-        const hits = rc.intersectObject(p.frame, false);
-        if (hits.length > 0) {
-          if (this.onSelectPortal) this.onSelectPortal(p.def.id);
-          this._desktopClick = null;
-          return;
-        }
+      const hits = rc.intersectObject(this.menuPlane, false);
+      if (hits.length > 0 && hits[0].uv) {
+        this._activateRow(this._hitTestRow(hits[0].uv));
       }
       this._desktopClick = null;
     }
   }
 
   // ---- helpers ------------------------------------------------------------
-
-  _createLabelSprite(text, color) {
-    const canvas = document.createElement('canvas');
-    canvas.width = 256;
-    canvas.height = 64;
-    const ctx = canvas.getContext('2d');
-    ctx.clearRect(0, 0, 256, 64);
-    ctx.fillStyle = '#ffffff';
-    ctx.font = 'bold 28px system-ui, sans-serif';
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'middle';
-    ctx.fillText(text, 128, 32);
-    const texture = new THREE.CanvasTexture(canvas);
-    texture.minFilter = THREE.LinearFilter;
-    const mat = new THREE.SpriteMaterial({ map: texture, transparent: true, depthTest: false });
-    return new THREE.Sprite(mat);
-  }
 
   _add(obj) {
     this.ctx.scene.add(obj);

--- a/src/scenes/GameHubScene.js
+++ b/src/scenes/GameHubScene.js
@@ -35,7 +35,10 @@ export default class GameHubScene {
     // forwards desktop clicks: it gates on `_desktopClick !== undefined`.
     this._desktopClick = null;
     this.progress = { tutorial: false, l1: false, l2: false, l3: false };
+    this._loadProgress();
+  }
 
+  _loadProgress() {
     try {
       const saved = sessionStorage.getItem('vdv-progress');
       if (saved) this.progress = JSON.parse(saved);
@@ -45,12 +48,15 @@ export default class GameHubScene {
   // ---- public lifecycle ---------------------------------------------------
 
   init() {
+    // Re-read on init in case sessionStorage was written between constructor
+    // and init (e.g. transitionToHub right after a level's onComplete).
+    this._loadProgress();
     this._buildMenu();
     this.spawn = { player: [0, 0, 0], camera: [0, 1.6, 1.0] };
   }
 
   update(dt, controllers) {
-    this._checkMenuActivation(controllers);
+    this._checkMenuActivation();
   }
 
   getGrabbables() { return this.grabbables; }
@@ -185,39 +191,22 @@ export default class GameHubScene {
     if (this.onSelectPortal) this.onSelectPortal(def.id);
   }
 
-  _checkMenuActivation(controllers) {
-    if (this._prevSelect === undefined) this._prevSelect = [false, false];
-
-    // VR: trigger raycast against menu plane
-    const session = this.ctx.renderer.xr.getSession();
-    if (session) {
-      let idx = 0;
-      for (const source of session.inputSources) {
-        if (idx >= 2) break;
-        const pressed = source.gamepad && source.gamepad.buttons[0] && source.gamepad.buttons[0].pressed;
-        const freshPress = pressed && !this._prevSelect[idx];
-
-        if (freshPress) {
-          const ctrl = controllers[idx];
-          if (ctrl) {
-            const tempMat = new THREE.Matrix4().extractRotation(ctrl.matrixWorld);
-            const rc = new THREE.Raycaster();
-            rc.ray.origin.setFromMatrixPosition(ctrl.matrixWorld);
-            rc.ray.direction.set(0, 0, -1).applyMatrix4(tempMat);
-            const hits = rc.intersectObject(this.menuPlane, false);
-            if (hits.length > 0 && hits[0].uv) {
-              this._activateRow(this._hitTestRow(hits[0].uv));
-              this._prevSelect[idx] = pressed;
-              return;
-            }
-          }
-        }
-        this._prevSelect[idx] = pressed;
-        idx++;
-      }
+  // VR trigger pull is dispatched by main.js's onSelectStart when no
+  // grabbable was hit. The controller event fires per-controller, so the
+  // matrix is the right one — no inputSources iteration to misalign.
+  _onControllerClick(controller) {
+    const tempMat = new THREE.Matrix4().extractRotation(controller.matrixWorld);
+    const rc = new THREE.Raycaster();
+    rc.ray.origin.setFromMatrixPosition(controller.matrixWorld);
+    rc.ray.direction.set(0, 0, -1).applyMatrix4(tempMat);
+    const hits = rc.intersectObject(this.menuPlane, false);
+    if (hits.length > 0 && hits[0].uv) {
+      this._activateRow(this._hitTestRow(hits[0].uv));
     }
+  }
 
-    // Desktop: forwarded mouse click
+  _checkMenuActivation() {
+    // Desktop: forwarded mouse click via main.js's mousedown handler.
     if (this._desktopClick) {
       const rc = new THREE.Raycaster();
       rc.setFromCamera(this._desktopClick, this.ctx.camera);


### PR DESCRIPTION
Closes #31

## What & why

The 3D-portal hub forced the user to teleport around a circular platform just to pick a level, and the squeeze-teleport ring was firing in every scene because the handlers were registered globally. Replaces both with a flat menu and removes teleport everywhere.

### Hub: clickable menu instead of portals

\`GameHubScene\` is rewritten as a single \`PlaneGeometry\` mesh with a \`CanvasTexture\`, anchored at \`(0, 1.5, -1.0)\`. The canvas renders a \"Select a Level\" title and four rows, one per level, each showing:

- a status icon (✓ complete, ► unlocked-incomplete, ✗ locked),
- the level label color-coded by level (or dimmed gray when locked),
- a status hint (\`COMPLETE\` / \`CLICK TO ENTER\` / \`LOCKED\`).

Trigger raycast (VR) or forwarded mouse click (desktop) hits the plane, the hit's UV is mapped to a row index, and an unlocked row fires \`onSelectPortal(id)\`. Locked rows are inert.

The progression chain (\`isUnlocked\` / \`progress\` / \`markComplete\`) is unchanged. \`markComplete\` now redraws the menu canvas, so level N's completion flips N+1 from locked → unlocked the next time the user is in the hub.

\`_desktopClick\` is initialized to \`null\` in the constructor — \`main.js\`'s mousedown handler gates click-forwarding on \`activeScene._desktopClick !== undefined\`, and the previous lazy-undefined initialization meant clicks were silently dropped before the first \`_checkPortalActivation\` call read the field.

### Teleport: removed everywhere, not gated

Removed from \`src/main.js\`:
- \`teleportMarker\` mesh + \`scene.add\` (was the green ring)
- \`updateTeleport()\` function
- \`updateTeleport(controller0/1)\` calls in the render loop
- \`squeezestart\` / \`squeezeend\` listeners on each XR controller
- \`controller.userData.teleporting\` field

\`handleThumbstickTeleport\` renamed to \`handleThumbstickLocomotion\` — it was always smooth-locomotion despite the name; renamed so a future reader doesn't confuse it with the deleted ring-snap teleport. \`selectstart\`/\`selectend\` (grab) handlers stay.

No remaining scene depends on squeeze-teleport (grep across \`TutorialScene\`, \`LevelOneScene\`, \`GameHubScene\` — only one comment-line reference remains, in \`LevelOneScene\` listing button indices).

## Testing

- \`npm run build\` — clean. Bundle is slightly smaller (the hub lost a lot of code).
- \`npm test\` — \`tests/scoring.test.js\` 9/9 pass (untouched by this PR; sanity).
- Did not run a headset session — the changes are deterministic geometry / event-handler edits and the diff is straightforward to review.

Suggested reviewer checks:
- Hub renders the menu, not the 3D portal ring layout.
- Teleport ring does not appear when squeezing the grip in any scene.
- Trigger-click / mouse-click on an unlocked row enters that level; clicking a locked row does nothing.
- Returning to the hub after completing the tutorial shows L1 unlocked.

## Changelog

Changed: hub now uses a flat click-to-enter menu instead of 3D portals, and teleport (squeeze-to-snap ring) is removed from all scenes; smooth thumbstick locomotion is unaffected.