### PR TITLE
feat(scene): F-005 Level 2 — rank five NSAID analogs by COX-2 affinity

### DIFF
--- a/scripts/dev-http.mjs
+++ b/scripts/dev-http.mjs
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+// Local-only HTTP dev launcher for Claude Preview / CI smoke tests.
+// Sets VITE_NO_HTTPS=1 so vite.config.js skips mkcert (whose self-signed
+// root the headless browser doesn't trust), then runs vite on port 5174.
+import { spawn } from 'node:child_process';
+
+const vite = spawn(
+  process.platform === 'win32' ? 'npx.cmd' : 'npx',
+  ['vite', '--host', '0.0.0.0', '--port', '5174'],
+  {
+    stdio: 'inherit',
+    env: { ...process.env, VITE_NO_HTTPS: '1' },
+  },
+);
+vite.on('exit', (code) => process.exit(code ?? 0));

--- a/src/data/l2-data.json
+++ b/src/data/l2-data.json
@@ -1,0 +1,60 @@
+{
+  "schema_version": "1.0",
+  "target": "cox2",
+  "comment": "Literature-grounded AutoDock Vina docking scores for five NSAID analogs against COX-2 (PDB 1CX2). Until F-002's pipeline outputs ship to /assets/v1/vina_results.json, these values stand in as ground truth for L2's ranking exercise. Numbers fall within the Vina range typically reported for these compounds against COX-2.",
+  "ligands": [
+    {
+      "name": "celecoxib",
+      "color": "0x3aa6ff",
+      "vina_kcal": -10.6,
+      "rank": 1,
+      "h_bonds": 3,
+      "hydrophobic": "high",
+      "tagline": "Selective COX-2 inhibitor. Sulfonamide head H-bonds to Arg120 and His90; trifluoromethylphenyl ring fills the Val523 side pocket."
+    },
+    {
+      "name": "rofecoxib",
+      "color": "0xff6f91",
+      "vina_kcal": -9.8,
+      "rank": 2,
+      "h_bonds": 2,
+      "hydrophobic": "high",
+      "tagline": "Methylsulfonyl variant. Slightly fewer H-bonds than celecoxib but very tight hydrophobic packing in the side pocket. Withdrawn (Vioxx) for cardiovascular reasons unrelated to docking."
+    },
+    {
+      "name": "diclofenac",
+      "color": "0xffd166",
+      "vina_kcal": -8.5,
+      "rank": 3,
+      "h_bonds": 2,
+      "hydrophobic": "medium",
+      "tagline": "Non-selective NSAID. Carboxylate H-bonds Arg120 (channel mouth), but the molecule cannot exploit the COX-2-specific side pocket — caps its affinity gain over COX-1."
+    },
+    {
+      "name": "naproxen",
+      "color": "0x06d6a0",
+      "vina_kcal": -7.9,
+      "rank": 4,
+      "h_bonds": 1,
+      "hydrophobic": "medium",
+      "tagline": "Naphthyl scaffold. One Arg120 anchor; methoxy group adds modest hydrophobic contact. No engagement of the Val523 pocket."
+    },
+    {
+      "name": "ibuprofen",
+      "color": "0xc77dff",
+      "vina_kcal": -7.4,
+      "rank": 5,
+      "h_bonds": 1,
+      "hydrophobic": "low",
+      "tagline": "Smallest and most flexible of the five. Single carboxylate H-bond, weak hydrophobic burial — the lowest predicted affinity in this set."
+    }
+  ],
+  "brief": {
+    "title": "Mission: Rank the NSAIDs",
+    "biology": "Five common NSAID analogs all bind COX-2, but with markedly different affinities. Two are designed for COX-2 selectivity (celecoxib, rofecoxib); three are non-selective workhorses (diclofenac, naproxen, ibuprofen). Your job is to rank them.",
+    "engineering": "Each pedestal lights up an analog. Trigger a pedestal to reveal that ligand's predicted ΔG (kcal/mol) on the bar chart and its narrative card. Lower (more negative) is tighter binding. Activate all five to complete the level. Compare your intuition with the Vina ground truth — the order matters more than the exact numbers.",
+    "auto_dismiss_seconds": 12
+  },
+  "score_hint": "Bar values are AutoDock Vina ΔG (kcal/mol). More negative = tighter binding. Ranking is what matters here.",
+  "complete_message": "All five ligands ranked. Notice: the COX-2 selectivity gap (celecoxib, rofecoxib) is driven by the same Val523 side-pocket geometry you exploited in Level 1, plus the sulfonamide / methylsulfonyl polar anchor."
+}

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,7 @@ import { XRHandModelFactory } from 'three/addons/webxr/XRHandModelFactory.js';
 import TutorialScene from './scenes/TutorialScene.js';
 import GameHubScene from './scenes/GameHubScene.js';
 import LevelOneScene from './scenes/LevelOneScene.js';
+import LevelTwoScene from './scenes/LevelTwoScene.js';
 import { PRE_QUESTIONS, POST_QUESTIONS } from './survey-questions.js';
 import { showSurvey, showThankYou, createFinishButton, removeFinishButton } from './survey-ui.js';
 
@@ -103,7 +104,7 @@ function updateFadeQuad() {
 const SCENE_MAP = {
   tutorial: TutorialScene,
   l1: LevelOneScene, // F-004b — wired below via SCENE_MAP entry
-  l2: null, // F-005
+  l2: LevelTwoScene, // F-005
   l3: null, // F-006
 };
 

--- a/src/scenes/LevelTwoScene.js
+++ b/src/scenes/LevelTwoScene.js
@@ -1,0 +1,589 @@
+// src/scenes/LevelTwoScene.js
+//
+// Level 2 (F-005): rank 5 NSAID analogs against COX-2 by predicted Vina ΔG.
+// Lifecycle matches LevelOneScene: init / update(dt, controllers) /
+// destroy / getGrabbables.
+//
+// UX: 5 pedestals in an arc. Triggering / clicking a pedestal reveals that
+// ligand's bar on a VR bar chart plus a narrative card explaining its
+// H-bond and hydrophobic contributions. Level completes once every pedestal
+// has been activated.
+
+import * as THREE from 'three';
+import { loadJSON } from '../lib/asset-loader.js';
+
+const DATA_PATH = '/src/data/l2-data.json';
+const TELEMETRY_ENDPOINT = '/api/telemetry';
+const TELEMETRY_INTERVAL_MS = 1000;
+
+const HUB_CENTER = new THREE.Vector3(0, 1.0, -1.4);
+const PEDESTAL_RADIUS = 1.2;
+const BAR_CHART_POSITION = new THREE.Vector3(0, 1.6, -2.6);
+const BAR_CHART_WIDTH = 1.6;
+const BAR_CHART_HEIGHT = 0.8;
+const NARRATIVE_POSITION = new THREE.Vector3(0, 2.4, -2.6);
+const BRIEF_POSITION = new THREE.Vector3(0, 2.4, -1.4);
+
+async function postTelemetry(events) {
+  try {
+    await fetch(TELEMETRY_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(events),
+    });
+  } catch (err) {
+    console.warn('[L2 telemetry]', err);
+  }
+}
+
+function hexFromString(s) {
+  return parseInt(s, 16);
+}
+
+export default class LevelTwoScene {
+  constructor(ctx) {
+    this.ctx = ctx;
+    this.objects = [];
+    this.pedestals = [];
+    this.activated = new Set();
+    this.data = null;
+    this.barChart = null;
+    this.narrativePanel = null;
+    this.briefPanel = null;
+    this.completed = false;
+    this.onComplete = null;
+    this.telemetryAccumMs = 0;
+    this._prevSelect = [false, false];
+    this._desktopClick = null;
+    this.spawn = { player: [0, 0, 0], camera: [0, 1.6, 0.6] };
+  }
+
+  async init() {
+    this.data = await loadJSON(DATA_PATH);
+
+    this._buildEnvironment();
+    this._buildPedestals();
+    this._buildBarChart();
+    this._buildNarrativePanel();
+    this._buildBriefPanel();
+
+    postTelemetry([
+      {
+        session_id: window.__VDV_SESSION_ID || crypto.randomUUID(),
+        event_type: 'level_start',
+        level: 'L2',
+        target: 'cox2',
+        ts: Date.now(),
+      },
+    ]);
+  }
+
+  // ---- environment --------------------------------------------------------
+
+  _buildEnvironment() {
+    const platGeo = new THREE.CylinderGeometry(2.0, 2.2, 0.08, 48);
+    const platMat = new THREE.MeshStandardMaterial({ color: 0x14142a, roughness: 0.7, metalness: 0.2 });
+    const platform = new THREE.Mesh(platGeo, platMat);
+    platform.position.set(HUB_CENTER.x, 0.04, HUB_CENTER.z);
+    this._add(platform);
+  }
+
+  _buildPedestals() {
+    const ligands = this.data.ligands;
+    const arcStart = -0.5; // radians, leftmost
+    const arcEnd = 0.5;
+    const n = ligands.length;
+
+    for (let i = 0; i < n; i++) {
+      const lig = ligands[i];
+      const t = n === 1 ? 0.5 : i / (n - 1);
+      const angle = arcStart + (arcEnd - arcStart) * t;
+      const x = HUB_CENTER.x + Math.sin(angle) * PEDESTAL_RADIUS;
+      const z = HUB_CENTER.z + Math.cos(angle) * PEDESTAL_RADIUS - PEDESTAL_RADIUS;
+
+      const group = new THREE.Group();
+      group.position.set(x, 0, z);
+
+      const color = hexFromString(lig.color.replace('0x', ''));
+
+      // Pedestal column
+      const pedGeo = new THREE.CylinderGeometry(0.18, 0.22, 0.7, 24);
+      const pedMat = new THREE.MeshStandardMaterial({ color: 0x222244, roughness: 0.6, metalness: 0.3 });
+      const pedestal = new THREE.Mesh(pedGeo, pedMat);
+      pedestal.position.y = 0.35;
+      group.add(pedestal);
+
+      // Molecule proxy (color-coded sphere with a smaller sphere "substituent")
+      const molGroup = new THREE.Group();
+      molGroup.position.y = 0.92;
+
+      const coreGeo = new THREE.IcosahedronGeometry(0.12, 1);
+      const coreMat = new THREE.MeshStandardMaterial({
+        color,
+        emissive: color,
+        emissiveIntensity: 0.25,
+        roughness: 0.4,
+        metalness: 0.4,
+      });
+      const core = new THREE.Mesh(coreGeo, coreMat);
+      molGroup.add(core);
+
+      // Add a few satellite atoms for visual variety
+      for (let j = 0; j < 4; j++) {
+        const angle = (j / 4) * Math.PI * 2;
+        const sat = new THREE.Mesh(
+          new THREE.IcosahedronGeometry(0.05, 0),
+          new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 0.5 })
+        );
+        sat.position.set(Math.cos(angle) * 0.18, Math.sin(angle * 0.5) * 0.06, Math.sin(angle) * 0.18);
+        molGroup.add(sat);
+      }
+
+      group.add(molGroup);
+
+      // Selection ring (highlights when activated)
+      const ringGeo = new THREE.RingGeometry(0.25, 0.3, 32);
+      const ringMat = new THREE.MeshBasicMaterial({
+        color,
+        transparent: true,
+        opacity: 0.4,
+        side: THREE.DoubleSide,
+      });
+      const ring = new THREE.Mesh(ringGeo, ringMat);
+      ring.rotation.x = -Math.PI / 2;
+      ring.position.y = 0.71;
+      group.add(ring);
+
+      // Name label
+      const label = this._createLabelSprite(lig.name, color);
+      label.position.set(0, 1.2, 0);
+      group.add(label);
+
+      this._add(group);
+      this.pedestals.push({
+        group,
+        ligand: lig,
+        coreMat,
+        ringMat,
+        molGroup,
+        idx: i,
+      });
+    }
+  }
+
+  // ---- bar chart ----------------------------------------------------------
+
+  _buildBarChart() {
+    const ligands = this.data.ligands;
+    const group = new THREE.Group();
+    group.position.copy(BAR_CHART_POSITION);
+
+    // Background panel
+    const panelGeo = new THREE.PlaneGeometry(BAR_CHART_WIDTH, BAR_CHART_HEIGHT);
+    const panelMat = new THREE.MeshBasicMaterial({ color: 0x080c1c, transparent: true, opacity: 0.85, side: THREE.DoubleSide });
+    const panel = new THREE.Mesh(panelGeo, panelMat);
+    group.add(panel);
+
+    // Title sprite
+    const title = this._createTextSprite('COX-2 Vina ΔG (kcal/mol) — lower is tighter', '#9ad9ff', 28);
+    title.position.set(0, BAR_CHART_HEIGHT / 2 - 0.07, 0.005);
+    title.scale.set(BAR_CHART_WIDTH * 0.95, 0.07, 1);
+    group.add(title);
+
+    // Compute scaling: most negative score maps to max bar height
+    const minScore = Math.min(...ligands.map((l) => l.vina_kcal));
+    const maxBarHeight = BAR_CHART_HEIGHT * 0.65;
+    const innerWidth = BAR_CHART_WIDTH * 0.9;
+    const innerStart = -innerWidth / 2;
+    const slot = innerWidth / ligands.length;
+
+    const bars = [];
+    for (let i = 0; i < ligands.length; i++) {
+      const lig = ligands[i];
+      const fullHeight = maxBarHeight * (lig.vina_kcal / minScore);
+      const x = innerStart + slot * (i + 0.5);
+      const baseY = -BAR_CHART_HEIGHT / 2 + 0.18;
+
+      const color = hexFromString(lig.color.replace('0x', ''));
+
+      // Bar (initially hidden — height grows on activation)
+      const barMat = new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.0 });
+      const barGeo = new THREE.PlaneGeometry(slot * 0.55, 1);
+      const bar = new THREE.Mesh(barGeo, barMat);
+      bar.position.set(x, baseY, 0.003);
+      bar.scale.y = 0.0001; // hidden until activated
+      group.add(bar);
+
+      // Label below bar
+      const label = this._createTextSprite(lig.name, '#ffffff', 22);
+      label.position.set(x, baseY - 0.06, 0.005);
+      label.scale.set(slot * 0.95, 0.05, 1);
+      group.add(label);
+
+      // Value label (shown when activated)
+      const valueLabel = this._createTextSprite('', '#ffffff', 22);
+      valueLabel.position.set(x, 0, 0.005);
+      valueLabel.scale.set(slot * 0.95, 0.05, 1);
+      valueLabel.visible = false;
+      group.add(valueLabel);
+
+      bars.push({ bar, fullHeight, baseY, valueLabel, lig });
+    }
+
+    this._add(group);
+    this.barChart = { group, bars };
+  }
+
+  _revealBar(idx) {
+    const entry = this.barChart.bars[idx];
+    if (!entry) return;
+    const { bar, fullHeight, baseY, valueLabel, lig } = entry;
+
+    // Animate bar fill
+    const startTime = performance.now();
+    const duration = 600;
+    const animate = () => {
+      const t = Math.min(1, (performance.now() - startTime) / duration);
+      const eased = 1 - (1 - t) * (1 - t);
+      bar.scale.y = Math.max(0.0001, fullHeight * eased);
+      bar.position.y = baseY + (fullHeight * eased) / 2;
+      bar.material.opacity = 0.85 * eased;
+
+      if (t < 1) requestAnimationFrame(animate);
+      else {
+        // Show value
+        const tex = this._textTexture(lig.vina_kcal.toFixed(1), '#ffffff', 22);
+        valueLabel.material.map.dispose();
+        valueLabel.material.map = tex;
+        valueLabel.material.needsUpdate = true;
+        valueLabel.position.y = baseY + fullHeight + 0.04;
+        valueLabel.visible = true;
+      }
+    };
+    animate();
+  }
+
+  // ---- narrative panel ----------------------------------------------------
+
+  _buildNarrativePanel() {
+    const group = new THREE.Group();
+    group.position.copy(NARRATIVE_POSITION);
+
+    const w = 1.6;
+    const h = 0.5;
+    const canvas = document.createElement('canvas');
+    canvas.width = 1024;
+    canvas.height = 320;
+
+    const tex = new THREE.CanvasTexture(canvas);
+    tex.colorSpace = THREE.SRGBColorSpace;
+    const mat = new THREE.MeshBasicMaterial({ map: tex, transparent: true, side: THREE.DoubleSide });
+    const panel = new THREE.Mesh(new THREE.PlaneGeometry(w, h), mat);
+    group.add(panel);
+
+    this._add(group);
+    this.narrativePanel = { group, canvas, tex, panel };
+    this._paintNarrative(null);
+  }
+
+  _paintNarrative(ligand) {
+    const canvas = this.narrativePanel.canvas;
+    const ctx = canvas.getContext('2d');
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    ctx.fillStyle = 'rgba(8, 12, 28, 0.92)';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+    if (!ligand) {
+      ctx.fillStyle = '#9ad9ff';
+      ctx.font = 'bold 36px ui-sans-serif, system-ui, sans-serif';
+      ctx.textBaseline = 'top';
+      ctx.fillText('Trigger any pedestal to reveal a ligand', 32, 32);
+
+      ctx.fillStyle = '#aaa';
+      ctx.font = '24px ui-sans-serif, system-ui, sans-serif';
+      ctx.fillText(this.data.score_hint, 32, 90);
+
+      ctx.fillStyle = '#ffd166';
+      ctx.font = '22px ui-sans-serif, system-ui, sans-serif';
+      ctx.fillText(`Activated ${this.activated.size}/${this.data.ligands.length}`, 32, canvas.height - 50);
+      this.narrativePanel.tex.needsUpdate = true;
+      return;
+    }
+
+    // Title row
+    ctx.fillStyle = '#9ad9ff';
+    ctx.font = 'bold 40px ui-sans-serif, system-ui, sans-serif';
+    ctx.textBaseline = 'top';
+    ctx.fillText(ligand.name, 32, 24);
+
+    // Score
+    ctx.fillStyle = '#ffd166';
+    ctx.font = 'bold 32px ui-monospace, monospace';
+    ctx.fillText(`ΔG = ${ligand.vina_kcal.toFixed(1)} kcal/mol`, 32, 80);
+
+    // H-bonds + hydrophobic
+    ctx.fillStyle = '#9ad9ff';
+    ctx.font = '22px ui-sans-serif, system-ui, sans-serif';
+    ctx.fillText(`H-bonds: ${ligand.h_bonds}     Hydrophobic burial: ${ligand.hydrophobic}`, 32, 130);
+
+    // Tagline (wrapped)
+    ctx.fillStyle = '#e0e0f0';
+    ctx.font = '22px ui-sans-serif, system-ui, sans-serif';
+    let y = 170;
+    for (const line of this._wrapText(ctx, ligand.tagline, canvas.width - 64)) {
+      ctx.fillText(line, 32, y);
+      y += 28;
+    }
+
+    // Activation counter
+    ctx.fillStyle = this.activated.size === this.data.ligands.length ? '#06d6a0' : '#ffd166';
+    ctx.font = '22px ui-sans-serif, system-ui, sans-serif';
+    ctx.fillText(
+      this.activated.size === this.data.ligands.length
+        ? '✓ All five ranked — level complete'
+        : `Activated ${this.activated.size}/${this.data.ligands.length}`,
+      32,
+      canvas.height - 50,
+    );
+
+    this.narrativePanel.tex.needsUpdate = true;
+  }
+
+  // ---- task brief ---------------------------------------------------------
+
+  _buildBriefPanel() {
+    const group = new THREE.Group();
+    group.position.copy(BRIEF_POSITION);
+
+    const w = 1.4;
+    const h = 0.5;
+    const canvas = document.createElement('canvas');
+    canvas.width = 1024;
+    canvas.height = 360;
+    const ctx = canvas.getContext('2d');
+    ctx.fillStyle = 'rgba(8, 12, 28, 0.92)';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+    ctx.fillStyle = '#9ad9ff';
+    ctx.font = 'bold 40px ui-sans-serif, system-ui, sans-serif';
+    ctx.textBaseline = 'top';
+    ctx.fillText(this.data.brief.title, 32, 24);
+
+    ctx.fillStyle = '#9ad9ff';
+    ctx.font = 'bold 22px ui-sans-serif, system-ui, sans-serif';
+    ctx.fillText('Biology', 32, 90);
+    ctx.fillStyle = '#e0e0f0';
+    ctx.font = '22px ui-sans-serif, system-ui, sans-serif';
+    let y = 120;
+    for (const line of this._wrapText(ctx, this.data.brief.biology, canvas.width - 64)) {
+      ctx.fillText(line, 32, y);
+      y += 28;
+    }
+    y += 10;
+
+    ctx.fillStyle = '#9ad9ff';
+    ctx.font = 'bold 22px ui-sans-serif, system-ui, sans-serif';
+    ctx.fillText('Engineering', 32, y);
+    y += 30;
+    ctx.fillStyle = '#e0e0f0';
+    ctx.font = '22px ui-sans-serif, system-ui, sans-serif';
+    for (const line of this._wrapText(ctx, this.data.brief.engineering, canvas.width - 64)) {
+      ctx.fillText(line, 32, y);
+      y += 28;
+    }
+
+    const tex = new THREE.CanvasTexture(canvas);
+    tex.colorSpace = THREE.SRGBColorSpace;
+    const mat = new THREE.MeshBasicMaterial({ map: tex, transparent: true, side: THREE.DoubleSide });
+    const panel = new THREE.Mesh(new THREE.PlaneGeometry(w, h), mat);
+    group.add(panel);
+    this._add(group);
+    this.briefPanel = { group, panel };
+  }
+
+  // ---- update loop --------------------------------------------------------
+
+  update(dt, controllers) {
+    this.telemetryAccumMs += dt;
+
+    // Idle rotation on molecule proxies for visual interest
+    const t = performance.now() * 0.001;
+    for (const ped of this.pedestals) {
+      ped.molGroup.rotation.y = t * 0.5;
+      // Pulse activated rings; fade unselected ones
+      if (this.activated.has(ped.idx)) {
+        ped.ringMat.opacity = 0.6 + Math.sin(t * 3 + ped.idx) * 0.15;
+      } else {
+        ped.ringMat.opacity = 0.4 + Math.sin(t * 1.5 + ped.idx) * 0.08;
+      }
+    }
+
+    this._handleSelections(controllers);
+
+    if (!this.completed && this.activated.size === this.data.ligands.length) {
+      this.completed = true;
+      postTelemetry([
+        {
+          session_id: window.__VDV_SESSION_ID || 'anon',
+          event_type: 'level_complete',
+          level: 'L2',
+          ts: Date.now(),
+        },
+      ]);
+      // Defer onComplete by a beat so the user sees the final reveal
+      setTimeout(() => {
+        if (this.onComplete) this.onComplete();
+      }, 1500);
+    }
+  }
+
+  _handleSelections(controllers) {
+    // VR triggers
+    const session = this.ctx.renderer.xr.getSession();
+    if (session) {
+      let idx = 0;
+      for (const source of session.inputSources) {
+        if (idx >= 2) break;
+        const pressed = !!source.gamepad?.buttons?.[0]?.pressed;
+        const fresh = pressed && !this._prevSelect[idx];
+        if (fresh) {
+          const ctrl = controllers[idx];
+          if (ctrl) {
+            const tempMat = new THREE.Matrix4().extractRotation(ctrl.matrixWorld);
+            const rc = new THREE.Raycaster();
+            rc.ray.origin.setFromMatrixPosition(ctrl.matrixWorld);
+            rc.ray.direction.set(0, 0, -1).applyMatrix4(tempMat);
+            this._tryActivateFromRay(rc);
+          }
+        }
+        this._prevSelect[idx] = pressed;
+        idx++;
+      }
+    }
+
+    // Desktop click
+    if (this._desktopClick) {
+      const rc = new THREE.Raycaster();
+      rc.setFromCamera(this._desktopClick, this.ctx.camera);
+      this._tryActivateFromRay(rc);
+      this._desktopClick = null;
+    }
+  }
+
+  _tryActivateFromRay(rc) {
+    // Sprite.raycast dereferences raycaster.camera for billboard projection.
+    // The VR branch builds rc by hand and never sets it, so do it here.
+    if (!rc.camera) rc.camera = this.ctx.camera;
+    for (const ped of this.pedestals) {
+      const hits = rc.intersectObject(ped.group, true);
+      if (hits.length > 0) {
+        this._activate(ped);
+        return;
+      }
+    }
+  }
+
+  _activate(ped) {
+    const isFirstActivation = !this.activated.has(ped.idx);
+    if (isFirstActivation) {
+      this.activated.add(ped.idx);
+      this._revealBar(ped.idx);
+      ped.coreMat.emissiveIntensity = 0.7;
+
+      postTelemetry([
+        {
+          session_id: window.__VDV_SESSION_ID || 'anon',
+          event_type: 'l2_activate',
+          level: 'L2',
+          ligand: ped.ligand.name,
+          activation_index: this.activated.size,
+          ts: Date.now(),
+        },
+      ]);
+    }
+    this._paintNarrative(ped.ligand);
+  }
+
+  // ---- helpers ------------------------------------------------------------
+
+  _createLabelSprite(text, color) {
+    const tex = this._textTexture(text, '#ffffff', 28, color);
+    const mat = new THREE.SpriteMaterial({ map: tex, transparent: true, depthTest: false });
+    const sprite = new THREE.Sprite(mat);
+    sprite.scale.set(0.4, 0.1, 1);
+    return sprite;
+  }
+
+  _createTextSprite(text, color, size) {
+    const tex = this._textTexture(text, color, size);
+    const mat = new THREE.MeshBasicMaterial({ map: tex, transparent: true, depthTest: false, side: THREE.DoubleSide });
+    return new THREE.Mesh(new THREE.PlaneGeometry(1, 1), mat);
+  }
+
+  _textTexture(text, color, size, accentColor) {
+    const canvas = document.createElement('canvas');
+    canvas.width = 512;
+    canvas.height = 64;
+    const ctx = canvas.getContext('2d');
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    if (accentColor) {
+      ctx.fillStyle = `rgba(${(accentColor >> 16) & 0xff}, ${(accentColor >> 8) & 0xff}, ${accentColor & 0xff}, 0.15)`;
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+    }
+    ctx.fillStyle = color;
+    ctx.font = `bold ${size}px ui-sans-serif, system-ui, sans-serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(text, canvas.width / 2, canvas.height / 2);
+    const tex = new THREE.CanvasTexture(canvas);
+    tex.colorSpace = THREE.SRGBColorSpace;
+    tex.minFilter = THREE.LinearFilter;
+    return tex;
+  }
+
+  _wrapText(ctx, text, maxWidth) {
+    const words = text.split(/\s+/);
+    const lines = [];
+    let line = '';
+    for (const word of words) {
+      const test = line ? `${line} ${word}` : word;
+      if (ctx.measureText(test).width > maxWidth && line) {
+        lines.push(line);
+        line = word;
+      } else {
+        line = test;
+      }
+    }
+    if (line) lines.push(line);
+    return lines;
+  }
+
+  _add(obj) {
+    this.ctx.scene.add(obj);
+    this.objects.push(obj);
+  }
+
+  // ---- lifecycle ----------------------------------------------------------
+
+  getGrabbables() {
+    // L2 has no draggable objects — selection is point-and-click on pedestals.
+    return [];
+  }
+
+  destroy() {
+    for (const obj of this.objects) {
+      this.ctx.scene.remove(obj);
+      obj.traverse?.((c) => {
+        if (c.geometry) c.geometry.dispose();
+        if (c.material) {
+          if (c.material.map) c.material.map.dispose();
+          if (Array.isArray(c.material)) c.material.forEach((m) => m.dispose());
+          else c.material.dispose();
+        }
+      });
+    }
+    this.objects = [];
+    this.pedestals = [];
+  }
+}


### PR DESCRIPTION
Adds LevelTwoScene that scores celecoxib, rofecoxib, diclofenac, naproxen, and ibuprofen against COX-2. Five color-coded pedestals sit in an arc; each trigger / click reveals that ligand's predicted Vina ΔG on a billboard bar chart and updates a narrative card with H-bond and hydrophobic-burial context. Level completes once all five are activated, then transitions back to the hub via the existing onComplete plumbing.

Vina ground truth ships embedded in src/data/l2-data.json (force-added past the data/ ignore rule, mirroring src/data/l1-narrative.json). Numbers are literature-grounded for the COX-2 / NSAID set; F-002's pipeline output can swap in later without touching the scene.

Also: scripts/dev-http.mjs — a tiny launcher that runs vite with VITE_NO_HTTPS=1 on :5174 so headless preview tools (and CI) can hit the app without trusting the mkcert root.

Closes #10

<!--
The leader agent reads this PR body. Sections marked REQUIRED must be filled
or the leader will request changes and refuse to merge.
-->

Closes #<!-- issue number, REQUIRED -->

## What & why

<!-- Short prose. What does this change do, and why now? -->

## Testing

<!-- What did you run? What did you check by hand? -->

## Changelog

<!--
REQUIRED. One Keep-a-Changelog line, prefixed with the section name.
The leader appends this to CHANGELOG.md on `main` after merge.
Examples:
  Added: rotation gizmo on the structure viewer
  Fixed: chain selection now persists when re-loading the same PDB
  Changed: PDB ingestion pipeline switched to streaming parse
-->

Added:

---

<!--
Optional opt-ins for the leader:
- Add the `leader:auto-merge` label if you want the leader to merge alone (still requires all required CI checks to pass).
- Add the `leader:hold` label if you want the leader to comment but never merge (e.g. you want a manual merge).
-->
