### PR TITLE
fix: graceful degradation for missing assets and null data

### DIFF
--- a/src/l3-scenario.js
+++ b/src/l3-scenario.js
@@ -6,9 +6,9 @@ export const COX2_SCORE = -10.2;
 export const SELECTIVITY_RATIO = '2.4x';
 
 // Per-frame animated objects
-const ligands = [];
-const cavityLights = [];
-const markers = [];
+let ligands = [];
+let cavityLights = [];
+let markers = [];
 
 // Deterministic sine-based displacement (no external noise lib).
 function displace(x, y, z) {
@@ -138,6 +138,11 @@ function createMarker() {
  * Build the L3 dual-pocket scene and add it to the given Three.js scene.
  */
 export function initL3Scene(scene) {
+  // Reset module-level arrays so re-init after destroy works cleanly.
+  ligands = [];
+  cavityLights = [];
+  markers = [];
+
   const l3Group = new THREE.Group();
   l3Group.name = 'L3';
 

--- a/src/lib/scoring.js
+++ b/src/lib/scoring.js
@@ -50,7 +50,7 @@ export function computeScore({
   thresholds = DEFAULT_THRESHOLDS,
 }) {
   if (!ligandCentroid || !vinaBestPose || !pocketAnnotation) {
-    throw new Error('computeScore: ligandCentroid, vinaBestPose, pocketAnnotation are required');
+    return { total: 0, components: { distance: 0, hBondHits: 0, clashes: 0 }, isBestPose: false, rawDistance: Infinity };
   }
 
   const bestCentroid = _toVec(vinaBestPose.ligand_centroid);

--- a/src/main.js
+++ b/src/main.js
@@ -128,7 +128,10 @@ function loadScene(sceneIdOrClass) {
 
   if (activeScene) activeScene.destroy();
   activeScene = new SceneClass({ scene, player, renderer, camera });
-  activeScene.init();
+  const initResult = activeScene.init();
+  if (initResult && typeof initResult.catch === 'function') {
+    initResult.catch((err) => console.error('[scene] init failed:', err));
+  }
 
   // Wire level completion → hub return
   if (activeScene.onComplete !== undefined) {

--- a/src/scenes/LevelOneScene.js
+++ b/src/scenes/LevelOneScene.js
@@ -126,9 +126,14 @@ export default class LevelOneScene {
       ligand_centroid: [0.0, 0.0, 0.0],
     };
     this.narrative = narrative || {
-      steps: [
-        { trigger: 'enter', title: 'COX-2 Docking', body: 'Dock celecoxib into the COX-2 active site. Grab the ligand and move it into the pocket.' },
-      ],
+      brief: {
+        title: 'COX-2 Docking',
+        biology: 'COX-2 is an enzyme upregulated during inflammation. Blocking it achieves an anti-inflammatory effect.',
+        engineering: 'Grab the celecoxib molecule and move it into the pocket.',
+        auto_dismiss_seconds: 15,
+      },
+      residue_notes: {},
+      score_hint: 'Score = α·shape + β·H-bonds − γ·clashes.',
     };
 
     // Build pivot — the centre of all scene objects

--- a/src/scenes/LevelThreeScene.js
+++ b/src/scenes/LevelThreeScene.js
@@ -78,7 +78,11 @@ export default class LevelThreeScene {
       this.l3Group.traverse((c) => {
         if (c.geometry) c.geometry.dispose();
         if (c.material) {
-          if (Array.isArray(c.material)) c.material.forEach((m) => m.dispose());
+          if (c.material.map) c.material.map.dispose();
+          if (Array.isArray(c.material)) c.material.forEach((m) => {
+            if (m.map) m.map.dispose();
+            m.dispose();
+          });
           else c.material.dispose();
         }
       });

--- a/src/scenes/LevelTwoScene.js
+++ b/src/scenes/LevelTwoScene.js
@@ -60,6 +60,20 @@ export default class LevelTwoScene {
 
   async init() {
     this.data = await loadJSON(DATA_PATH);
+    if (!this.data) {
+      this.data = {
+        ligands: [
+          { name: 'celecoxib', color: '0x3aa6ff', vina_kcal: -10.6, rank: 1, h_bonds: 3, hydrophobic: 'high', tagline: 'Selective COX-2 inhibitor.' },
+          { name: 'rofecoxib', color: '0xff6f91', vina_kcal: -9.8, rank: 2, h_bonds: 2, hydrophobic: 'high', tagline: 'Methylsulfonyl variant.' },
+          { name: 'diclofenac', color: '0xffd166', vina_kcal: -8.5, rank: 3, h_bonds: 2, hydrophobic: 'medium', tagline: 'Non-selective NSAID.' },
+          { name: 'naproxen', color: '0x06d6a0', vina_kcal: -7.9, rank: 4, h_bonds: 1, hydrophobic: 'medium', tagline: 'Naphthyl scaffold.' },
+          { name: 'ibuprofen', color: '0xc77dff', vina_kcal: -7.4, rank: 5, h_bonds: 1, hydrophobic: 'low', tagline: 'Smallest and most flexible.' },
+        ],
+        brief: { title: 'Rank the NSAIDs', biology: 'Five NSAID analogs bind COX-2 with different affinities.', engineering: 'Trigger pedestals to reveal scores.', auto_dismiss_seconds: 12 },
+        score_hint: 'Lower ΔG = tighter binding.',
+        complete_message: 'All five ranked.',
+      };
+    }
 
     this._buildEnvironment();
     this._buildPedestals();
@@ -253,7 +267,7 @@ export default class LevelTwoScene {
       else {
         // Show value
         const tex = this._textTexture(lig.vina_kcal.toFixed(1), '#ffffff', 22);
-        valueLabel.material.map.dispose();
+        if (valueLabel.material.map) valueLabel.material.map.dispose();
         valueLabel.material.map = tex;
         valueLabel.material.needsUpdate = true;
         valueLabel.position.y = baseY + fullHeight + 0.04;

--- a/src/ui/narrative-panel.js
+++ b/src/ui/narrative-panel.js
@@ -45,11 +45,25 @@ function paintBrief(canvas, narrative) {
   ctx.fillStyle = 'rgba(8, 12, 28, 0.9)';
   ctx.fillRect(0, 0, BRIEF_CANVAS_W, BRIEF_CANVAS_H);
 
+  const brief = narrative?.brief;
+  if (!brief) {
+    ctx.fillStyle = '#9ad9ff';
+    ctx.font = 'bold 36px ui-sans-serif, system-ui, sans-serif';
+    ctx.textBaseline = 'top';
+    ctx.fillText(narrative?.steps?.[0]?.title || 'Dock the ligand', 32, 32);
+    ctx.fillStyle = '#e0e0f0';
+    ctx.font = '22px ui-sans-serif, system-ui, sans-serif';
+    for (const line of wrapText(ctx, narrative?.steps?.[0]?.body || '', BRIEF_CANVAS_W - 64)) {
+      ctx.fillText(line, 32, 80);
+    }
+    return;
+  }
+
   // Title
   ctx.fillStyle = '#9ad9ff';
   ctx.font = 'bold 48px ui-sans-serif, system-ui, sans-serif';
   ctx.textBaseline = 'top';
-  ctx.fillText(narrative.brief.title, 32, 24);
+  ctx.fillText(brief.title, 32, 24);
 
   // Body
   const bodyTextStart = 96;
@@ -59,7 +73,7 @@ function paintBrief(canvas, narrative) {
   ctx.fillText('Biology', 32, bodyTextStart);
   ctx.fillStyle = '#e0e0f0';
   let y = bodyTextStart + 36;
-  for (const line of wrapText(ctx, narrative.brief.biology, BRIEF_CANVAS_W - 64)) {
+  for (const line of wrapText(ctx, brief.biology || '', BRIEF_CANVAS_W - 64)) {
     ctx.fillText(line, 32, y);
     y += 30;
   }
@@ -69,7 +83,7 @@ function paintBrief(canvas, narrative) {
   ctx.fillText('Engineering', 32, y);
   ctx.fillStyle = '#e0e0f0';
   y += 36;
-  for (const line of wrapText(ctx, narrative.brief.engineering, BRIEF_CANVAS_W - 64)) {
+  for (const line of wrapText(ctx, brief.engineering || '', BRIEF_CANVAS_W - 64)) {
     ctx.fillText(line, 32, y);
     y += 30;
   }
@@ -142,7 +156,7 @@ export function buildNarrativePanel({
 
   // Residue side-notes
   for (const residue of pocketAnnotation.key_residues || []) {
-    const note = narrative.residue_notes?.[residue.id];
+    const note = narrative.residue_notes?.[residue.id] || narrative.residue_notes?.[residue.name];
     if (!note) continue;
     const canvas = document.createElement('canvas');
     canvas.width = 512;
@@ -184,7 +198,7 @@ export function buildNarrativePanel({
 
   function update(dtMs, camera) {
     dtSinceBoot += dtMs;
-    const autoDismissMs = (narrative.brief?.auto_dismiss_seconds ?? 15) * 1000;
+    const autoDismissMs = (narrative?.brief?.auto_dismiss_seconds ?? 15) * 1000;
     if (dtSinceBoot >= autoDismissMs) brief.visible = false;
     if (camera) {
       brief.lookAt(camera.position);


### PR DESCRIPTION
## Summary
- **scoring.js**: Return safe defaults instead of throwing on null inputs (ligandCentroid, vinaBestPose, pocketAnnotation)
- **LevelTwoScene**: Add fallback data when `loadJSON` returns null so the level still works without the JSON file
- **LevelOneScene**: Fix narrative fallback to use `brief` structure (matching what `buildNarrativePanel` expects) instead of `steps`
- **narrative-panel**: Guard against missing `narrative.brief`, support `residue.name` lookup alongside `residue.id` for pocket annotation compatibility
- **l3-scenario.js**: Reset module-level arrays on re-init to prevent stale references and duplicate animations when L3 is loaded/destroyed/loaded again
- **LevelThreeScene**: Dispose material maps in `destroy()` to fix CanvasTexture leaks
- **LevelTwoScene**: Null-guard `valueLabel.material.map` before `dispose()`
- **main.js**: Catch async `init()` rejections to prevent unhandled promise errors

## Test plan
- [ ] `npm run build` passes (verified)
- [ ] Launch `npm run dev` — hub loads, all 4 levels are clickable
- [ ] L1 loads with procedural fallbacks (no GLB assets needed)
- [ ] L2 loads with fallback data (no l2-data.json needed)
- [ ] L3 loads, cutscene plays, scene transitions back to hub
- [ ] No console errors from null data or missing narrative.brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)