### PR TITLE
fix(vr): unblock scene transitions by driving fade from main animation loop

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -106,7 +106,7 @@ function registerScene(id, SceneClass) {
   SCENE_MAP[id] = SceneClass;
 }
 
-function loadScene(sceneIdOrClass) {
+async function loadScene(sceneIdOrClass) {
   let SceneClass;
   let sceneId = null;
 
@@ -127,25 +127,37 @@ function loadScene(sceneIdOrClass) {
   desktopHeld = null;
 
   if (activeScene) activeScene.destroy();
-  activeScene = new SceneClass({ scene, player, renderer, camera });
-  activeScene.init();
+  const nextScene = new SceneClass({ scene, player, renderer, camera });
 
-  // Wire level completion → hub return
-  if (activeScene.onComplete !== undefined) {
-    activeScene.onComplete = () => {
+  // Wire callbacks BEFORE init so async init paths cannot fire onComplete /
+  // onSelectPortal against a null-target scene. (P0-1 fix.)
+  if (nextScene.onComplete !== undefined) {
+    nextScene.onComplete = () => {
       if (sceneId) markProgress(sceneId);
       transitionToHub();
     };
   }
-
-  // Wire hub portal selection → scene transitions
-  if (activeScene.onSelectPortal !== undefined) {
-    activeScene.onSelectPortal = (portalId) => {
+  if (nextScene.onSelectPortal !== undefined) {
+    nextScene.onSelectPortal = (portalId) => {
       if (SCENE_MAP[portalId]) {
         transitionToScene(portalId);
       }
     };
   }
+
+  // Await async init so first update() does not run on a half-built scene.
+  // Sync init() returns undefined which Promise.resolve handles fine.
+  try {
+    await Promise.resolve(nextScene.init());
+  } catch (err) {
+    console.error('[scene] init failed', err);
+    nextScene.destroy?.();
+    return;
+  }
+
+  // Only commit nextScene to activeScene after init resolves so the render
+  // loop never sees a scene mid-construction.
+  activeScene = nextScene;
 
   grabbables = activeScene.getGrabbables();
   if (activeScene.enableSkipShortcut) activeScene.enableSkipShortcut();
@@ -156,30 +168,30 @@ function loadScene(sceneIdOrClass) {
   }
 }
 
-function transitionToScene(sceneId) {
+async function transitionToScene(sceneId) {
   if (transitioning) return;
   transitioning = true;
-  _fadeOut(300).then(() => {
-    loadScene(sceneId);
-    renderer.render(scene, camera);
-    _fadeIn(300).then(() => {
-      transitioning = false;
-    });
-  });
+  await _fadeOut(300);
+  await loadScene(sceneId);
+  await _fadeIn(300);
+  transitioning = false;
 }
 
-function transitionToHub() {
+async function transitionToHub() {
   if (transitioning) return;
   transitioning = true;
-  _fadeOut(300).then(() => {
-    loadScene(GameHubScene);
-    _syncHubProgress();
-    renderer.render(scene, camera);
-    _fadeIn(300).then(() => {
-      transitioning = false;
-    });
-  });
+  await _fadeOut(300);
+  await loadScene(GameHubScene);
+  _syncHubProgress();
+  await _fadeIn(300);
+  transitioning = false;
 }
+
+// Fade animation state — ticked from the main animation loop so it works
+// in both desktop and immersive-VR (window.requestAnimationFrame is paused
+// during a WebXR session on Quest, so the previous standalone-rAF fade
+// never resolved and transitions hung forever).
+let fadeAnim = null; // { from, to, startTime, duration, resolve }
 
 function _fadeOut(duration) {
   return _animateFade(0, 1, duration);
@@ -191,17 +203,21 @@ function _fadeIn(duration) {
 
 function _animateFade(from, to, duration) {
   return new Promise(resolve => {
-    const start = performance.now();
-    function step() {
-      const t = Math.min(1, (performance.now() - start) / duration);
-      fadeMat.opacity = from + (to - from) * t;
-      updateFadeQuad();
-      renderer.render(scene, camera);
-      if (t < 1) requestAnimationFrame(step);
-      else resolve();
-    }
-    step();
+    fadeAnim = { from, to, startTime: null, duration, resolve };
   });
+}
+
+function _tickFade(time) {
+  if (!fadeAnim) return;
+  if (fadeAnim.startTime === null) fadeAnim.startTime = time;
+  const t = Math.min(1, (time - fadeAnim.startTime) / fadeAnim.duration);
+  fadeMat.opacity = fadeAnim.from + (fadeAnim.to - fadeAnim.from) * t;
+  updateFadeQuad();
+  if (t >= 1) {
+    const r = fadeAnim.resolve;
+    fadeAnim = null;
+    r();
+  }
 }
 
 // ---- Progress tracking -----------------------------------------------------
@@ -414,8 +430,15 @@ let lastTime = 0;
 renderer.setAnimationLoop((time) => {
   if (!animating) return;
 
-  const dt = lastTime ? time - lastTime : 16;
+  // Clamp dt so a Meta-menu pause / focus-loss doesn't trip state-machine
+  // timers in a single frame on resume. (P1: dt clamp.)
+  const rawDt = lastTime ? time - lastTime : 16;
+  const dt = Math.min(rawDt, 100);
   lastTime = time;
+
+  // Drive fade animation from the main loop so it works in immersive VR
+  // (where window.requestAnimationFrame is paused).
+  _tickFade(time);
 
   handleThumbstickLocomotion();
   handleDesktopFallback(dt);
@@ -462,9 +485,9 @@ async function runPostSurvey() {
   showThankYou();
 }
 
-function startExperience() {
+async function startExperience() {
   animating = true;
-  loadScene(GameHubScene);
+  await loadScene(GameHubScene);
   _syncHubProgress();
   renderer.render(scene, camera);
   createFinishButton(() => runPostSurvey());

--- a/src/scenes/LevelOneScene.js
+++ b/src/scenes/LevelOneScene.js
@@ -128,6 +128,10 @@ export default class LevelOneScene {
     this.pivot = pivot;
     this.ready = true;
 
+    // Snapshot current A/B state so a held button doesn't produce a phantom
+    // first-frame action (P0-2).
+    this._snapshotButtons();
+
     postTelemetry([
       {
         session_id: window.__VDV_SESSION_ID || crypto.randomUUID(),
@@ -138,6 +142,17 @@ export default class LevelOneScene {
         ts: Date.now(),
       },
     ]);
+  }
+
+  _snapshotButtons() {
+    const session = this.ctx.renderer.xr.getSession();
+    if (!session) return;
+    for (const source of session.inputSources) {
+      if (source.handedness !== 'left' || !source.gamepad) continue;
+      const buttons = source.gamepad.buttons || [];
+      this.lastButtons.A = !!buttons[4]?.pressed;
+      this.lastButtons.B = !!buttons[5]?.pressed;
+    }
   }
 
   update(dt, controllers) {

--- a/src/scenes/LevelTwoScene.js
+++ b/src/scenes/LevelTwoScene.js
@@ -53,7 +53,9 @@ export default class LevelTwoScene {
     this.completed = false;
     this.onComplete = null;
     this.telemetryAccumMs = 0;
-    this._prevSelect = [false, false];
+    // Map<handedness, boolean> — keyed by 'left'/'right' so inputSources
+    // order swaps (controller↔hand handover) don't break edge detection.
+    this._prevSelect = new Map();
     this._desktopClick = null;
     this.spawn = { player: [0, 0, 0], camera: [0, 1.6, 0.6] };
   }
@@ -67,6 +69,10 @@ export default class LevelTwoScene {
     this._buildNarrativePanel();
     this._buildBriefPanel();
 
+    // Snapshot current trigger state so a held-from-hub trigger doesn't
+    // produce a phantom first-frame selection here.
+    this._snapshotTriggers();
+
     postTelemetry([
       {
         session_id: window.__VDV_SESSION_ID || crypto.randomUUID(),
@@ -76,6 +82,15 @@ export default class LevelTwoScene {
         ts: Date.now(),
       },
     ]);
+  }
+
+  _snapshotTriggers() {
+    const session = this.ctx.renderer.xr.getSession();
+    if (!session) return;
+    for (const src of session.inputSources) {
+      if (!src.handedness || !src.gamepad) continue;
+      this._prevSelect.set(src.handedness, !!src.gamepad.buttons?.[0]?.pressed);
+    }
   }
 
   // ---- environment --------------------------------------------------------
@@ -439,14 +454,16 @@ export default class LevelTwoScene {
   }
 
   _handleSelections(controllers) {
-    // VR triggers
+    // VR triggers — key prev-state by handedness, not array index, so
+    // controller↔hand swaps mid-session don't desync edge detection.
     const session = this.ctx.renderer.xr.getSession();
     if (session) {
       let idx = 0;
       for (const source of session.inputSources) {
-        if (idx >= 2) break;
+        if (!source.handedness || !source.gamepad) { idx++; continue; }
         const pressed = !!source.gamepad?.buttons?.[0]?.pressed;
-        const fresh = pressed && !this._prevSelect[idx];
+        const prev = this._prevSelect.get(source.handedness) ?? false;
+        const fresh = pressed && !prev;
         if (fresh) {
           const ctrl = controllers[idx];
           if (ctrl) {
@@ -457,7 +474,7 @@ export default class LevelTwoScene {
             this._tryActivateFromRay(rc);
           }
         }
-        this._prevSelect[idx] = pressed;
+        this._prevSelect.set(source.handedness, pressed);
         idx++;
       }
     }


### PR DESCRIPTION
## Summary

- Hub→scene transitions deadlocked in immersive-VR: clicking Tutorial / L1 / L2 / L3 on the hub menu would fade out and never finish. Manually verified on Quest 3S that this PR makes the click work.
- Drive `_animateFade` from `renderer.setAnimationLoop` instead of a standalone `requestAnimationFrame` chain. Three.js auto-selects `XRSession.requestAnimationFrame` while presenting in immersive VR; `window.requestAnimationFrame` is paused there, which is why the previous Promise-chain fade never resolved.
- Bundles two correctness fixes uncovered while debugging (held-button phantom press on scene entry; async `init()` racing the callback wiring).

## Root cause

`window.requestAnimationFrame` does not fire during a WebXR `immersive-vr` session on Quest browser. The previous fade implementation stepped via `window.requestAnimationFrame`, so `await _fadeOut(300)` blocked forever. `transitioning = true` was never cleared, no further input was accepted, and the UX appeared as "click stuck on hub". Pressing the Meta button to leave VR resumed `window.rAF`, the queued Promises flushed, and the transition completed by the time the user re-entered VR — explaining the "quit and re-enter loaded the tutorial directly" symptom.

## Changes

### `src/main.js`
- `_animateFade` no longer drives its own rAF loop; it stores fade state in a module-scoped `fadeAnim` and `_tickFade(time)` is called from `renderer.setAnimationLoop`. Same Promise contract for callers (`await _fadeOut(...)`).
- `loadScene` is now `async`. Wires `onComplete` / `onSelectPortal` **before** `init()`, awaits `init()` (so async loaders like `LevelOneScene` finish before any update tick), and only commits `activeScene = nextScene` once init resolves. If init throws it logs + cleans up rather than leaving a half-built scene live.
- `transitionToScene` / `transitionToHub` / `startExperience` are async and `await loadScene` so the fade-in starts only after the new scene is real.
- Main loop clamps `dt = Math.min(rawDt, 100)` so a Meta-menu pause doesn't trip per-state timers in a single frame on resume.

### `src/scenes/LevelOneScene.js`
- Adds `_snapshotButtons()`, called at the end of `init()`, so `lastButtons.A` / `.B` reflect the live trigger state. Previously defaulted to `false`, so a held A/B on entry produced a phantom dismiss / redock on frame 1.

### `src/scenes/LevelTwoScene.js`
- `_prevSelect` is now a `Map<handedness, boolean>` instead of `[false, false]` indexed by `session.inputSources` insertion order. Survives controller↔hand handover (which can reorder `inputSources`).
- New `_snapshotTriggers()` called at the end of `init()` snapshots the current trigger state per hand so a held trigger from the hub doesn't auto-activate a pedestal on frame 1.

## Test plan

- [x] `npx vitest run` — 9/9 pass (scoring kernel, no regression).
- [x] Manual smoke on Quest 3S (user-verified): hub → click Tutorial enters Tutorial; previous "fade stays black, click stuck" reproduces no longer.
- [ ] Manual smoke: hub → L1, L1 → hub → L2, L2 → hub → L3 round-trip (next round, currently blocked by separate L3 cutscene HTML-overlay deadlock that is **out of scope** for this PR).
- [ ] Desktop fallback: pre-survey → hub → click each row with mouse, confirm transitions still smooth (fade is now driven from the same loop, so behaviour is unchanged outside VR).

## Out of scope

- L3 cutscene HTML overlay during WebXR session (separate P0; cutscene Promise hangs because DOM overlays don't render inside an XR rig without `XRDOMOverlay` session feature).
- Centralized `handleSelectStart` hook contract across scenes (P0-4 in the local code-review doc).
- Haptics / `AudioContext.resume` / `setPixelRatio` cap / foveation (P1 polish bundle).

## Changelog

### Fixed
- VR scene transitions deadlocking when clicking hub menu items (\`window.requestAnimationFrame\` paused during \`immersive-vr\` session); fade now ticks from the main animation loop. First-frame phantom press on L1 / L2 entry from a held trigger / face button. Async \`LevelOneScene.init\` racing the scene callback wiring.