### PR TITLE
feat(tutorial+l1+l2): ghost-overlay UX, bundled HUD, full L2 docking, L3 cut

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -98,7 +98,7 @@ function updateFadeQuad() {
 const SCENE_MAP = {
   tutorial: TutorialScene,
   l1: LevelOneScene,
-  l2: null, // F-005
+  l2: LevelTwoScene, // F-005
   l3: LevelThreeScene, // F-006
 };
 

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,7 @@ import TutorialScene from './scenes/TutorialScene.js';
 import GameHubScene from './scenes/GameHubScene.js';
 import LevelOneScene from './scenes/LevelOneScene.js';
 import LevelTwoScene from './scenes/LevelTwoScene.js';
-import LevelThreeScene from './scenes/LevelThreeScene.js';
+// L3 cut from MVP — see GameHubScene.LEVEL_DEFS / SCENE_MAP below.
 import { PRE_QUESTIONS, POST_QUESTIONS } from './survey-questions.js';
 import { showSurvey, showThankYou, createFinishButton, removeFinishButton } from './survey-ui.js';
 
@@ -99,7 +99,8 @@ const SCENE_MAP = {
   tutorial: TutorialScene,
   l1: LevelOneScene,
   l2: LevelTwoScene, // F-005
-  l3: LevelThreeScene, // F-006
+  // l3 dropped from the MVP scope — keep the slot null so the hub menu
+  // entry (if any leaks back in) just no-ops.
 };
 
 function registerScene(id, SceneClass) {

--- a/src/main.js
+++ b/src/main.js
@@ -313,23 +313,34 @@ function onSelectEnd(controller) {
 const controller0 = buildController(0);
 const controller1 = buildController(1);
 
-function handleThumbstickLocomotion() {
+// Player is intentionally locked in space — thumbsticks no longer drive
+// player position. Per [[webxr-locomotion-comfort]] educational scenes
+// should disable smooth-locomotion (high cybersickness risk). Instead the
+// thumbstick is forwarded to the active scene so it can use it to translate
+// the object the user is interacting with.
+//
+// Convention (Quest 3 / 3S Touch Plus, see [[quest3s-button-map]]):
+//   left  axes[2/3] = leftX  / leftY   (forward push = -1)
+//   right axes[2/3] = rightX / rightY  (forward push = -1)
+function handleThumbstickInput(dt) {
   const session = renderer.xr.getSession();
   if (!session) return;
+  const dz = (v) => (Math.abs(v) < 0.15 ? 0 : v);
+  let leftX = 0, leftY = 0, rightX = 0, rightY = 0;
   for (const source of session.inputSources) {
     if (!source.gamepad || !source.handedness) continue;
-    const axes = source.gamepad.axes;
-    if (axes.length < 4) continue;
-    const x = axes[2];
-    const y = axes[3];
-    if (Math.abs(x) > 0.5 || Math.abs(y) > 0.5) {
-      const speed = 0.04;
-      const forward = new THREE.Vector3(0, 0, -1).applyQuaternion(camera.getWorldQuaternion(new THREE.Quaternion()));
-      forward.y = 0; forward.normalize();
-      const right = new THREE.Vector3().crossVectors(forward, new THREE.Vector3(0, 1, 0)).negate();
-      player.position.addScaledVector(forward, -y * speed);
-      player.position.addScaledVector(right, x * speed);
+    const a = source.gamepad.axes;
+    if (a.length < 4) continue;
+    if (source.handedness === 'left') {
+      leftX = dz(a[2]);
+      leftY = dz(a[3]);
+    } else if (source.handedness === 'right') {
+      rightX = dz(a[2]);
+      rightY = dz(a[3]);
     }
+  }
+  if (activeScene && activeScene.applyThumbstickInput) {
+    activeScene.applyThumbstickInput({ leftX, leftY, rightX, rightY }, dt);
   }
 }
 
@@ -440,7 +451,7 @@ renderer.setAnimationLoop((time) => {
   // (where window.requestAnimationFrame is paused).
   _tickFade(time);
 
-  handleThumbstickLocomotion();
+  handleThumbstickInput(dt);
   handleDesktopFallback(dt);
 
   if (activeScene && !transitioning) {

--- a/src/main.js
+++ b/src/main.js
@@ -171,20 +171,32 @@ async function loadScene(sceneIdOrClass) {
 async function transitionToScene(sceneId) {
   if (transitioning) return;
   transitioning = true;
-  await _fadeOut(300);
-  await loadScene(sceneId);
-  await _fadeIn(300);
-  transitioning = false;
+  try {
+    await _fadeOut(300);
+    await loadScene(sceneId);
+    await _fadeIn(300);
+  } catch (err) {
+    console.error('[transition] scene transition failed', err);
+  } finally {
+    // Always release the lock — otherwise a thrown error in load/fade
+    // pins transitioning=true and the user is stuck on a dead screen.
+    transitioning = false;
+  }
 }
 
 async function transitionToHub() {
   if (transitioning) return;
   transitioning = true;
-  await _fadeOut(300);
-  await loadScene(GameHubScene);
-  _syncHubProgress();
-  await _fadeIn(300);
-  transitioning = false;
+  try {
+    await _fadeOut(300);
+    await loadScene(GameHubScene);
+    _syncHubProgress();
+    await _fadeIn(300);
+  } catch (err) {
+    console.error('[transition] hub transition failed', err);
+  } finally {
+    transitioning = false;
+  }
 }
 
 // Fade animation state — ticked from the main animation loop so it works

--- a/src/scenes/GameHubScene.js
+++ b/src/scenes/GameHubScene.js
@@ -60,6 +60,11 @@ export default class GameHubScene {
   update(dt, controllers) {
     this._updateHover(controllers);
     this._checkMenuActivation();
+    // Deferred trigger click — see _onControllerClick comment for why.
+    if (this._pendingClick) {
+      this._pendingClick = false;
+      if (this.hoveredRow >= 0) this._activateRow(this.hoveredRow);
+    }
   }
 
   getGrabbables() { return this.grabbables; }
@@ -208,17 +213,15 @@ export default class GameHubScene {
   }
 
   // VR trigger pull is dispatched by main.js's onSelectStart when no
-  // grabbable was hit. The controller event fires per-controller, so the
-  // matrix is the right one — no inputSources iteration to misalign.
-  _onControllerClick(controller) {
-    const tempMat = new THREE.Matrix4().extractRotation(controller.matrixWorld);
-    const rc = new THREE.Raycaster();
-    rc.ray.origin.setFromMatrixPosition(controller.matrixWorld);
-    rc.ray.direction.set(0, 0, -1).applyMatrix4(tempMat);
-    const hits = rc.intersectObject(this.menuPlane, false);
-    if (hits.length > 0 && hits[0].uv) {
-      this._activateRow(this._hitTestRow(hits[0].uv));
-    }
+  // grabbable was hit. We **don't** raycast here — selectstart fires from
+  // a WebXR input event whose timing is decoupled from the XR frame loop,
+  // so `controller.matrixWorld` may be stale. Instead just flag a pending
+  // click; `update()` consumes it next frame and uses the live hoveredRow
+  // (raycasted with fresh matrices in `_updateHover`) as the activation
+  // target. This eliminates the "hover lights up but click does nothing"
+  // race that came from the ray missing the menu plane on the event tick.
+  _onControllerClick(_controller) {
+    this._pendingClick = true;
   }
 
   _checkMenuActivation() {

--- a/src/scenes/GameHubScene.js
+++ b/src/scenes/GameHubScene.js
@@ -11,10 +11,10 @@ const LEVEL_DEFS = [
   { id: 'tutorial', label: 'Tutorial',              color: '#06d6a0' },
   { id: 'l1',       label: 'Level 1 — COX-2 Dock',  color: '#3aa6ff' },
   { id: 'l2',       label: 'Level 2 — Rank NSAIDs', color: '#ffd166' },
-  { id: 'l3',       label: 'Level 3 — Selectivity', color: '#ff6f91' },
+  // L3 (Selectivity) cut from MVP scope.
 ];
 
-const UNLOCK_ORDER = ['tutorial', 'l1', 'l2', 'l3'];
+const UNLOCK_ORDER = ['tutorial', 'l1', 'l2'];
 
 const CANVAS_W = 768;
 const CANVAS_H = 512;

--- a/src/scenes/LevelOneScene.js
+++ b/src/scenes/LevelOneScene.js
@@ -12,7 +12,14 @@ import { buildNarrativePanel } from '../ui/narrative-panel.js';
 
 const ASSET_BASE = '/assets/v1';
 const NARRATIVE_PATH = '/src/data/l1-narrative.json';
-const SPAWN_OFFSET = new THREE.Vector3(0.6, 0.0, 0.0); // ≥ 6 Å along +x relative to pocket
+// Ligand spawns 15 Å away from pocket — far enough that it doesn't overlap
+// the protein at start, close enough that the user can drag it in.
+const SPAWN_OFFSET = new THREE.Vector3(15.0, 4.0, 0.0);
+// Material colours (light blue protein, bright green ligand, semi-transparent
+// ghost target). Picked for high contrast in VR's typical dim scene.
+const PROTEIN_COLOR = 0x88aaff;
+const LIGAND_COLOR  = 0x4ae87a;
+const GHOST_COLOR   = 0x06d6a0;
 const TELEMETRY_INTERVAL_MS = 1000;
 const BEST_POSE_BADGE_FADE_MS = 5000;
 // PyMOL exports geometry in Å (1 unit = 1 Å). At unit Three scale a 5 nm
@@ -44,6 +51,29 @@ function _amplifyQuat(delta, gain) {
   const newHalf = halfAngle * gain;
   const sinNew = Math.sin(newHalf);
   return new THREE.Quaternion(ax * sinNew, ay * sinNew, az * sinNew, Math.cos(newHalf));
+}
+
+// Recolour every material on a loaded GLB subtree. Materials are cloned so
+// shared assets (e.g. ghost ligand later cloning the real ligand) keep
+// independent overrides.
+function _recolor(root, hex, opts = {}) {
+  const { emissiveIntensity = 0.0, transparent = false, opacity = 1.0 } = opts;
+  root.traverse((c) => {
+    if (!c.material) return;
+    const list = Array.isArray(c.material) ? c.material : [c.material];
+    const cloned = list.map((m) => {
+      const cm = m.clone();
+      if (cm.color) cm.color.setHex(hex);
+      if (cm.emissive) {
+        cm.emissive.setHex(hex);
+        cm.emissiveIntensity = emissiveIntensity;
+      }
+      cm.transparent = transparent || cm.transparent;
+      if (transparent) cm.opacity = opacity;
+      return cm;
+    });
+    c.material = Array.isArray(c.material) ? cloned : cloned[0];
+  });
 }
 
 async function postTelemetry(events) {
@@ -126,6 +156,9 @@ export default class LevelOneScene {
     );
     cox2Surface.applyMatrix4(offsetMatrix);
     cox2Cartoon.applyMatrix4(offsetMatrix);
+    // Recolour: light-blue protein, contrasting against the green ligand.
+    _recolor(cox2Surface, PROTEIN_COLOR, { transparent: true, opacity: 0.55 });
+    _recolor(cox2Cartoon, PROTEIN_COLOR, { emissiveIntensity: 0.15 });
     pivot.add(cox2Surface);
     pivot.add(cox2Cartoon);
 
@@ -133,6 +166,7 @@ export default class LevelOneScene {
     ligand.applyMatrix4(offsetMatrix);
     ligand.position.add(SPAWN_OFFSET);
     ligand.userData.grabbable = true;
+    _recolor(ligand, LIGAND_COLOR, { emissiveIntensity: 0.45 });
     pivot.add(ligand);
     this.ligand = ligand;
     this.spawnTransform = {
@@ -140,28 +174,36 @@ export default class LevelOneScene {
       quaternion: ligand.quaternion.clone(),
     };
 
-    // Score readout — head-locked HUD, child of camera so it stays in the
-    // top-left of the user's view regardless of model translation /
-    // rotation / scale. (User asked: "scoring 表格固定在屏幕的左上角不
-    // 要让它参与模型移动等操作".)
+    // Build a single HUD bundle on the camera that holds both the score
+    // readout and the dismissible task brief — so they sit together in
+    // the user's view rather than the brief floating in front of the
+    // protein. (User: "描述框不要嵌入和模型本身，和分数看板放在一起".)
+    this.hud = new THREE.Group();
+    this.hud.position.set(-0.45, 0.05, -1.2);
+    this.ctx.camera.add(this.hud);
+
     this.readout = buildReadout({
       pocketCenter: { x: 0, y: 0, z: 0 },
       camera: null,
     });
-    this.readout.group.position.set(-0.45, 0.30, -1.2);
+    this.readout.group.position.set(0, 0.22, 0);
     this.readout.group.scale.setScalar(0.7);
-    this.ctx.camera.add(this.readout.group);
-    // Not pushed to `this.objects` — destroy handles HUD detach explicitly.
+    this.hud.add(this.readout.group);
 
-    // Narrative panel — also world-locked. Skip residue side-notes for now;
-    // attaching them in pivot-local frame would also shrink them, and the
-    // task brief is the critical onboarding text.
+    // Narrative — keep `group` at scene root for any future world-locked
+    // residue notes, but pull the brief mesh into the HUD bundle.
     this.narrativePanel = buildNarrativePanel({
       pocketCenter: { x: 0, y: 0, z: 0 },
       pocketAnnotation: { ...pocket, key_residues: [] },
       narrative,
       scoreReadoutAnchor: { x: 0, y: 0.5, z: 0 },
     });
+    if (this.narrativePanel.brief) {
+      this.narrativePanel.group.remove(this.narrativePanel.brief);
+      this.narrativePanel.brief.position.set(0, -0.20, 0);
+      this.narrativePanel.brief.scale.setScalar(0.42);
+      this.hud.add(this.narrativePanel.brief);
+    }
     this.narrativePanel.group.position.copy(this._uiWorldAnchor);
     this.ctx.scene.add(this.narrativePanel.group);
     this.objects.push(this.narrativePanel.group);
@@ -171,6 +213,9 @@ export default class LevelOneScene {
     // the user *where* in the protein to place the ligand. Lives inside
     // the pivot so it scales / translates / rotates with the protein.
     this._buildTargetGhost(ligand, pocketCenter, pivot);
+
+    // Pre-build the dock-success card; shown when bestPoseFired transitions.
+    this._buildSuccessCard();
 
     this.pivot = pivot;
     // Spawn even farther so the user starts with a full view of the protein.
@@ -272,6 +317,7 @@ export default class LevelOneScene {
       this.bestPoseFired = true;
       this.bestPoseFireTime = this.dtSinceInit;
       this.readout.showBadge();
+      this._showSuccessCard(result.total);
       postTelemetry([
         {
           session_id: window.__VDV_SESSION_ID || 'anon',
@@ -381,6 +427,12 @@ export default class LevelOneScene {
           Math.min(PIVOT_SCALE_MAX, s.pivotScaleStart * ratio),
         );
         this.pivot.scale.setScalar(newScale);
+        // If the ligand is currently held by a controller (i.e. parented
+        // away from `pivot`), it doesn't inherit pivot.scale anymore. Match
+        // its world size to the protein so they bimanual-zoom together.
+        if (this.ligand && this.ligand.parent && this.ligand.parent !== this.pivot) {
+          this.ligand.scale.setScalar(newScale);
+        }
         const midDelta = currentMid.clone().sub(s.bimanualMidStart);
         this.pivot.position.copy(s.pivotPosStart).add(midDelta);
         this._syncUiAnchor();
@@ -395,31 +447,20 @@ export default class LevelOneScene {
     const ghost = ligand.clone(true);
     ghost.traverse((c) => {
       if (!c.material) return;
-      // Materials must be cloned so we don't bleed our overrides into the
-      // grabbable real ligand.
-      c.material = Array.isArray(c.material)
-        ? c.material.map((m) => {
-            const cm = m.clone();
-            cm.transparent = true;
-            cm.opacity = 0.30;
-            cm.depthWrite = false;
-            if (cm.emissive) {
-              cm.emissive.setHex(0x06d6a0);
-              cm.emissiveIntensity = 0.7;
-            }
-            return cm;
-          })
-        : (() => {
-            const cm = c.material.clone();
-            cm.transparent = true;
-            cm.opacity = 0.30;
-            cm.depthWrite = false;
-            if (cm.emissive) {
-              cm.emissive.setHex(0x06d6a0);
-              cm.emissiveIntensity = 0.7;
-            }
-            return cm;
-          })();
+      const list = Array.isArray(c.material) ? c.material : [c.material];
+      const cloned = list.map((m) => {
+        const cm = m.clone();
+        cm.transparent = true;
+        cm.opacity = 0.45;
+        cm.depthWrite = false;
+        if (cm.color) cm.color.setHex(GHOST_COLOR);
+        if (cm.emissive) {
+          cm.emissive.setHex(GHOST_COLOR);
+          cm.emissiveIntensity = 1.4;
+        }
+        return cm;
+      });
+      c.material = Array.isArray(c.material) ? cloned : cloned[0];
     });
     ghost.position.set(
       this.vinaBest.ligand_centroid[0] - pocketCenter.x,
@@ -429,6 +470,79 @@ export default class LevelOneScene {
     ghost.userData.grabbable = false;
     pivot.add(ghost);
     this.targetGhost = ghost;
+  }
+
+  _buildSuccessCard() {
+    const canvas = document.createElement('canvas');
+    canvas.width = 1024;
+    canvas.height = 512;
+    const ctx = canvas.getContext('2d');
+    ctx.fillStyle = 'rgba(6, 214, 160, 0.95)';
+    ctx.beginPath();
+    ctx.roundRect(0, 0, 1024, 512, 36);
+    ctx.fill();
+    ctx.fillStyle = '#0a2e22';
+    ctx.font = 'bold 110px ui-sans-serif, system-ui, sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText('PERFECT DOCK!', 512, 200);
+    ctx.font = 'bold 56px ui-sans-serif, system-ui, sans-serif';
+    ctx.fillText('COX-2 + celecoxib', 512, 320);
+    ctx.font = '40px ui-sans-serif, system-ui, sans-serif';
+    this._successCardCanvas = canvas;
+    this._successCardCtx = ctx;
+    const tex = new THREE.CanvasTexture(canvas);
+    tex.colorSpace = THREE.SRGBColorSpace;
+    const mat = new THREE.MeshBasicMaterial({ map: tex, transparent: true, opacity: 0, depthTest: false });
+    const mesh = new THREE.Mesh(new THREE.PlaneGeometry(0.9, 0.45), mat);
+    mesh.position.set(0, 0, -1.4);
+    mesh.visible = false;
+    mesh.renderOrder = 999;
+    this.ctx.camera.add(mesh);
+    this.successCard = mesh;
+  }
+
+  _showSuccessCard(scoreTotal) {
+    if (!this.successCard || !this._successCardCanvas) return;
+    const ctx = this._successCardCtx;
+    // Repaint with current score below the title line.
+    ctx.fillStyle = 'rgba(6, 214, 160, 0.95)';
+    ctx.beginPath();
+    ctx.roundRect(0, 360, 1024, 152, 24);
+    ctx.fill();
+    ctx.fillStyle = '#0a2e22';
+    ctx.font = 'bold 56px ui-sans-serif, system-ui, sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(`Score: ${scoreTotal.toFixed(2)} / 1.00`, 512, 440);
+    if (this.successCard.material.map) this.successCard.material.map.needsUpdate = true;
+
+    this.successCard.visible = true;
+    const startTime = performance.now();
+    const fadeIn = 280;
+    const hold = 2400;
+    const fadeOut = 540;
+    const total = fadeIn + hold + fadeOut;
+    const animate = () => {
+      const elapsed = performance.now() - startTime;
+      let opacity;
+      if (elapsed < fadeIn) opacity = elapsed / fadeIn;
+      else if (elapsed < fadeIn + hold) opacity = 1;
+      else if (elapsed < total) opacity = 1 - (elapsed - fadeIn - hold) / fadeOut;
+      else { this.successCard.visible = false; return; }
+      this.successCard.material.opacity = opacity;
+      requestAnimationFrame(animate);
+    };
+    animate();
+
+    // Haptic burst on both controllers
+    const session = this.ctx.renderer.xr.getSession();
+    if (session) {
+      for (const src of session.inputSources) {
+        const a = src.gamepad?.hapticActuators?.[0];
+        a?.pulse(0.8, 90);
+      }
+    }
   }
 
   _syncUiAnchor() {
@@ -485,17 +599,23 @@ export default class LevelOneScene {
   }
 
   destroy() {
-    // HUD readout is parented to the camera, not the scene — explicit detach
-    // so it doesn't survive into the next scene.
-    if (this.readout?.group?.parent) {
-      this.readout.group.parent.remove(this.readout.group);
-      this.readout.group.traverse?.((c) => {
+    // HUD bundle (score readout + brief + success card) is parented to the
+    // camera, not the scene — explicit detach so it doesn't survive into
+    // the next scene.
+    if (this.hud?.parent) {
+      this.hud.parent.remove(this.hud);
+      this.hud.traverse?.((c) => {
         if (c.geometry) c.geometry.dispose();
         if (c.material) {
           if (Array.isArray(c.material)) c.material.forEach((m) => m.dispose());
           else c.material.dispose();
         }
       });
+    }
+    if (this.successCard?.parent) {
+      this.successCard.parent.remove(this.successCard);
+      if (this.successCard.geometry) this.successCard.geometry.dispose();
+      if (this.successCard.material) this.successCard.material.dispose();
     }
     for (const obj of this.objects) {
       this.ctx.scene.remove(obj);

--- a/src/scenes/LevelOneScene.js
+++ b/src/scenes/LevelOneScene.js
@@ -83,6 +83,28 @@ function _recolor(root, hex, opts = {}) {
   });
 }
 
+// Layer a dark line overlay on every mesh in the subtree — the silhouette
+// edges read as "sticks" against the (now translucent) surface so the
+// composite gives a ball+stick impression without re-exporting geometry.
+function _addStickOverlay(root, lineColorHex = 0x111122, angleThresholdDeg = 20) {
+  const mats = [];
+  root.traverse((c) => {
+    if (!c.geometry || !(c.isMesh)) return;
+    const edges = new THREE.EdgesGeometry(c.geometry, angleThresholdDeg);
+    const mat = new THREE.LineBasicMaterial({
+      color: lineColorHex,
+      transparent: true,
+      opacity: 0.55,
+      depthWrite: false,
+    });
+    mats.push(mat);
+    const lines = new THREE.LineSegments(edges, mat);
+    lines.userData.stickOverlay = true;
+    c.add(lines);
+  });
+  return mats;
+}
+
 async function postTelemetry(events) {
   try {
     await fetch(TELEMETRY_ENDPOINT, {
@@ -178,7 +200,9 @@ export default class LevelOneScene {
     ligand.applyMatrix4(offsetMatrix);
     ligand.position.add(SPAWN_OFFSET);
     ligand.userData.grabbable = true;
-    _recolor(ligand, LIGAND_COLOR, { emissiveIntensity: 0.45 });
+    // Translucent surface + dark edge overlay → ball+stick reading.
+    _recolor(ligand, LIGAND_COLOR, { emissiveIntensity: 0.45, transparent: true, opacity: 0.55 });
+    _addStickOverlay(ligand);
     pivot.add(ligand);
     this.ligand = ligand;
     this.spawnTransform = {

--- a/src/scenes/LevelOneScene.js
+++ b/src/scenes/LevelOneScene.js
@@ -6,15 +6,19 @@
 
 import * as THREE from 'three';
 import { loadGLB, loadJSON, extractAtomPositions } from '../lib/asset-loader.js';
-import { computeScore } from '../lib/scoring.js';
+import { computeScore, BEST_POSE } from '../lib/scoring.js';
 import { buildReadout } from '../ui/score-readout.js';
 import { buildNarrativePanel } from '../ui/narrative-panel.js';
 
 const ASSET_BASE = '/assets/v1';
 const NARRATIVE_PATH = '/src/data/l1-narrative.json';
-// Ligand spawns 15 Å away from pocket — far enough that it doesn't overlap
-// the protein at start, close enough that the user can drag it in.
-const SPAWN_OFFSET = new THREE.Vector3(15.0, 4.0, 0.0);
+// Ligand spawns 50 Å away from the pocket centre — clear of the protein's
+// bounding sphere (~25 Å radius from active site). User pulls the ligand
+// in across that gap.
+const SPAWN_OFFSET = new THREE.Vector3(50.0, 10.0, 0.0);
+// Best-pose judgment range — relax 30 % beyond the kernel's strict
+// `BEST_POSE.distance` so docking is forgiving in VR.
+const BEST_POSE_RELAX = 1.30;
 // Material colours (light blue protein, bright green ligand, semi-transparent
 // ghost target). Picked for high contrast in VR's typical dim scene.
 const PROTEIN_COLOR = 0x88aaff;
@@ -313,7 +317,15 @@ export default class LevelOneScene {
     this.readout.update(result);
     this.narrativePanel.update(dt, camera);
 
-    if (result.isBestPose && !this.bestPoseFired) {
+    // Relaxed best-pose: kernel's strict `BEST_POSE.distance` (3 Å) is
+    // hard to nail in VR, widen by `BEST_POSE_RELAX` while keeping the
+    // strict H-bond requirement so the chemistry is still earned.
+    const hBondHitsCount = result.components?.hBondHits ?? 0;
+    const relaxedBestPose =
+      result.rawDistance < BEST_POSE.distance * BEST_POSE_RELAX &&
+      hBondHitsCount >= BEST_POSE.hBondHits;
+
+    if ((result.isBestPose || relaxedBestPose) && !this.bestPoseFired) {
       this.bestPoseFired = true;
       this.bestPoseFireTime = this.dtSinceInit;
       this.readout.showBadge();

--- a/src/scenes/LevelOneScene.js
+++ b/src/scenes/LevelOneScene.js
@@ -351,6 +351,13 @@ export default class LevelOneScene {
       this.bestPoseFireTime = this.dtSinceInit;
       this.readout.showBadge();
       this._showSuccessCard(result.total);
+      // Hand off to the scene manager (markProgress + transitionToHub)
+      // after the success card finishes its hold so the level actually
+      // completes. Total card duration ≈ 3.2 s; fire onComplete just past
+      // peak so the user reads the score before fade.
+      this._completeTimer = setTimeout(() => {
+        if (this.onComplete) this.onComplete();
+      }, 3200);
       postTelemetry([
         {
           session_id: window.__VDV_SESSION_ID || 'anon',
@@ -600,7 +607,8 @@ export default class LevelOneScene {
       const bPressed = !!buttons[5]?.pressed;
 
       if (aPressed && !this.lastButtons.A) {
-        this.narrativePanel.dismissBrief();
+        // Toggle (was dismiss-only) so users can recall the brief.
+        this.narrativePanel.toggleBrief();
       }
       if (bPressed && !this.lastButtons.B) {
         this._redock();
@@ -632,6 +640,7 @@ export default class LevelOneScene {
   }
 
   destroy() {
+    if (this._completeTimer) { clearTimeout(this._completeTimer); this._completeTimer = null; }
     // HUD bundle (score readout + brief + success card) is parented to the
     // camera, not the scene — explicit detach so it doesn't survive into
     // the next scene.

--- a/src/scenes/LevelOneScene.js
+++ b/src/scenes/LevelOneScene.js
@@ -19,6 +19,9 @@ const SPAWN_OFFSET = new THREE.Vector3(50.0, 10.0, 0.0);
 // Best-pose judgment range — relax 30 % beyond the kernel's strict
 // `BEST_POSE.distance` so docking is forgiving in VR.
 const BEST_POSE_RELAX = 1.30;
+// A composite score ≥ this also counts as a successful dock — independent
+// from the strict hBond / distance gate, so good geometry alone passes.
+const PASS_SCORE_THRESHOLD = 0.70;
 // Material colours (light blue protein, bright green ligand, semi-transparent
 // ghost target). Picked for high contrast in VR's typical dim scene.
 const PROTEIN_COLOR = 0x88aaff;
@@ -206,8 +209,23 @@ export default class LevelOneScene {
       this.narrativePanel.group.remove(this.narrativePanel.brief);
       this.narrativePanel.brief.position.set(0, -0.20, 0);
       this.narrativePanel.brief.scale.setScalar(0.42);
+      // Brief is HUD now — never let the protein occlude it.
+      this.narrativePanel.brief.material.depthTest = false;
+      this.narrativePanel.brief.material.depthWrite = false;
+      this.narrativePanel.brief.renderOrder = 998;
       this.hud.add(this.narrativePanel.brief);
     }
+    // Same for the score readout meshes — disable depth test so the
+    // bundle is always visible even if the camera enters the protein.
+    this.readout.group.traverse((c) => {
+      if (!c.material) return;
+      const mats = Array.isArray(c.material) ? c.material : [c.material];
+      for (const m of mats) {
+        m.depthTest = false;
+        m.depthWrite = false;
+      }
+      c.renderOrder = 998;
+    });
     this.narrativePanel.group.position.copy(this._uiWorldAnchor);
     this.ctx.scene.add(this.narrativePanel.group);
     this.objects.push(this.narrativePanel.group);
@@ -324,8 +342,11 @@ export default class LevelOneScene {
     const relaxedBestPose =
       result.rawDistance < BEST_POSE.distance * BEST_POSE_RELAX &&
       hBondHitsCount >= BEST_POSE.hBondHits;
+    // Composite-score pass: total >= 0.70 alone counts. Lets a user with
+    // very good fit but only one H-bond still complete the level.
+    const scorePass = result.total >= PASS_SCORE_THRESHOLD;
 
-    if ((result.isBestPose || relaxedBestPose) && !this.bestPoseFired) {
+    if ((result.isBestPose || relaxedBestPose || scorePass) && !this.bestPoseFired) {
       this.bestPoseFired = true;
       this.bestPoseFireTime = this.dtSinceInit;
       this.readout.showBadge();

--- a/src/scenes/LevelOneScene.js
+++ b/src/scenes/LevelOneScene.js
@@ -646,6 +646,20 @@ export default class LevelOneScene {
 
   destroy() {
     if (this._completeTimer) { clearTimeout(this._completeTimer); this._completeTimer = null; }
+    // The grabbable ligand may have been trigger-grabbed at scene end —
+    // in that case `controller.attach(ligand)` reparented it onto the
+    // (persistent) controller node, NOT pivot, so pivot disposal won't
+    // clean it up and the mesh persists into the next scene.
+    if (this.ligand && this.ligand.parent) {
+      this.ligand.parent.remove(this.ligand);
+      this.ligand.traverse?.((c) => {
+        if (c.geometry) c.geometry.dispose();
+        if (c.material) {
+          if (Array.isArray(c.material)) c.material.forEach((m) => m.dispose());
+          else c.material.dispose();
+        }
+      });
+    }
     // HUD bundle (score readout + brief + success card) is parented to the
     // camera, not the scene — explicit detach so it doesn't survive into
     // the next scene.

--- a/src/scenes/LevelOneScene.js
+++ b/src/scenes/LevelOneScene.js
@@ -19,7 +19,7 @@ const BEST_POSE_BADGE_FADE_MS = 5000;
 // protein renders 50 m wide and the user is inside the molecule. Scale the
 // whole pivot down so the protein sits desk-sized in front of the user.
 // User can grip-bimanual to rescale.
-const PIVOT_SCALE = 0.025;
+const PIVOT_SCALE = 0.015;
 // Grip gesture limits — see [[experience-vr-scene-transition-tutorial-snap-patterns-2026-04-25]]
 // + [[prior-art-nanome]] (bimanual scale is the muscle memory we steal).
 const PIVOT_SCALE_MIN = 0.005;
@@ -121,15 +121,18 @@ export default class LevelOneScene {
       quaternion: ligand.quaternion.clone(),
     };
 
-    // Score readout — world-locked, NOT inside pivot, so it stays full-size
-    // when the user rescales the protein with bimanual grip.
+    // Score readout — head-locked HUD, child of camera so it stays in the
+    // top-left of the user's view regardless of model translation /
+    // rotation / scale. (User asked: "scoring 表格固定在屏幕的左上角不
+    // 要让它参与模型移动等操作".)
     this.readout = buildReadout({
       pocketCenter: { x: 0, y: 0, z: 0 },
       camera: null,
     });
-    this.readout.group.position.copy(this._uiWorldAnchor);
-    this.ctx.scene.add(this.readout.group);
-    this.objects.push(this.readout.group);
+    this.readout.group.position.set(-0.45, 0.30, -1.2);
+    this.readout.group.scale.setScalar(0.7);
+    this.ctx.camera.add(this.readout.group);
+    // Not pushed to `this.objects` — destroy handles HUD detach explicitly.
 
     // Narrative panel — also world-locked. Skip residue side-notes for now;
     // attaching them in pivot-local frame would also shrink them, and the
@@ -144,9 +147,15 @@ export default class LevelOneScene {
     this.ctx.scene.add(this.narrativePanel.group);
     this.objects.push(this.narrativePanel.group);
 
+    // Target ghost — semi-transparent green clone of the ligand at the
+    // Vina-best docked pose. Same UX as Tutorial's ghost-overlay: tells
+    // the user *where* in the protein to place the ligand. Lives inside
+    // the pivot so it scales / translates / rotates with the protein.
+    this._buildTargetGhost(ligand, pocketCenter, pivot);
+
     this.pivot = pivot;
-    // Spawn farther back so the user actually sees the whole protein.
-    this.spawn = { player: [0, 0, 1.0], camera: [0, 1.6, 1.6] };
+    // Spawn even farther so the user starts with a full view of the protein.
+    this.spawn = { player: [0, 0, 1.5], camera: [0, 1.6, 2.2] };
     this.ready = true;
 
     // Snapshot current A/B state so a held button doesn't produce a phantom
@@ -235,10 +244,9 @@ export default class LevelOneScene {
       vinaBestPose: reframedVina,
     });
 
-    // Re-bind the camera each frame so billboard look-at uses the live XR pose.
-    if (camera) this.readout.group.userData._cam = camera;
+    // Score readout is now a child of the camera (HUD), so it always faces
+    // the user without an explicit lookAt.
     this.readout.update(result);
-    if (camera) this.readout.group.lookAt(camera.position);
     this.narrativePanel.update(dt, camera);
 
     if (result.isBestPose && !this.bestPoseFired) {
@@ -282,7 +290,7 @@ export default class LevelOneScene {
     if (!session) return;
 
     let leftDown = false, rightDown = false;
-    let leftPos = null, rightPos = null;
+    let leftCtrl = null, rightCtrl = null;
 
     let idx = 0;
     for (const src of session.inputSources) {
@@ -290,15 +298,8 @@ export default class LevelOneScene {
       const gripPressed = !!src.gamepad.buttons?.[1]?.pressed; // index 1 = squeeze/grip
       const ctrl = controllers[idx];
       if (!ctrl) { idx++; continue; }
-      const pos = new THREE.Vector3();
-      ctrl.getWorldPosition(pos);
-      if (src.handedness === 'left') {
-        leftDown = gripPressed;
-        leftPos = pos;
-      } else if (src.handedness === 'right') {
-        rightDown = gripPressed;
-        rightPos = pos;
-      }
+      if (src.handedness === 'left') { leftDown = gripPressed; leftCtrl = ctrl; }
+      else if (src.handedness === 'right') { rightDown = gripPressed; rightCtrl = ctrl; }
       idx++;
     }
 
@@ -311,18 +312,31 @@ export default class LevelOneScene {
     }
 
     if (numActive === 1) {
-      const handPos = leftDown ? leftPos : rightPos;
+      // Single-hand grip = 6-DOF "grab the world": pivot follows the
+      // controller's full pose (translate + rotate). Snapshot the relative
+      // pose at grip-start; each frame reapply it so pivot rides on the
+      // controller without ever physically reparenting (which would mess
+      // with the ligand's grabbable child).
+      const ctrl = leftDown ? leftCtrl : rightCtrl;
+      if (!ctrl) return;
       if (s.active !== 1) {
         s.active = 1;
-        s.handStart = handPos.clone();
-        s.pivotPosStart = this.pivot.position.clone();
+        // relMat = ctrlWorld⁻¹ · pivotWorld
+        const ctrlInv = ctrl.matrixWorld.clone().invert();
+        s.relPivotMat = ctrlInv.multiply(this.pivot.matrixWorld);
       } else {
-        const delta = handPos.clone().sub(s.handStart);
-        this.pivot.position.copy(s.pivotPosStart).add(delta);
+        // pivot.world = ctrlWorld · relMat   (preserve current scale)
+        const newMat = ctrl.matrixWorld.clone().multiply(s.relPivotMat);
+        const _scale = new THREE.Vector3();
+        newMat.decompose(this.pivot.position, this.pivot.quaternion, _scale);
+        // _scale is the snapshot scale; we leave pivot.scale untouched so
+        // bimanual scale that may have happened earlier is preserved.
         this._syncUiAnchor();
       }
     } else {
       // Two-handed grip — bimanual scale + translate around the midpoint.
+      const leftPos = new THREE.Vector3(); leftCtrl.getWorldPosition(leftPos);
+      const rightPos = new THREE.Vector3(); rightCtrl.getWorldPosition(rightPos);
       const currentDist = leftPos.distanceTo(rightPos);
       const currentMid = leftPos.clone().add(rightPos).multiplyScalar(0.5);
       if (s.active !== 2) {
@@ -345,13 +359,56 @@ export default class LevelOneScene {
     }
   }
 
+  // Visual target: low-opacity green clone of the ligand at the Vina-best
+  // docked pose. Tells the user where to overlay their grabbed ligand.
+  _buildTargetGhost(ligand, pocketCenter, pivot) {
+    if (!this.vinaBest?.ligand_centroid) return;
+    const ghost = ligand.clone(true);
+    ghost.traverse((c) => {
+      if (!c.material) return;
+      // Materials must be cloned so we don't bleed our overrides into the
+      // grabbable real ligand.
+      c.material = Array.isArray(c.material)
+        ? c.material.map((m) => {
+            const cm = m.clone();
+            cm.transparent = true;
+            cm.opacity = 0.30;
+            cm.depthWrite = false;
+            if (cm.emissive) {
+              cm.emissive.setHex(0x06d6a0);
+              cm.emissiveIntensity = 0.7;
+            }
+            return cm;
+          })
+        : (() => {
+            const cm = c.material.clone();
+            cm.transparent = true;
+            cm.opacity = 0.30;
+            cm.depthWrite = false;
+            if (cm.emissive) {
+              cm.emissive.setHex(0x06d6a0);
+              cm.emissiveIntensity = 0.7;
+            }
+            return cm;
+          })();
+    });
+    ghost.position.set(
+      this.vinaBest.ligand_centroid[0] - pocketCenter.x,
+      this.vinaBest.ligand_centroid[1] - pocketCenter.y,
+      this.vinaBest.ligand_centroid[2] - pocketCenter.z,
+    );
+    ghost.userData.grabbable = false;
+    pivot.add(ghost);
+    this.targetGhost = ghost;
+  }
+
   _syncUiAnchor() {
-    // Keep the world-locked UI (score readout + narrative brief) attached
-    // to the pivot's WORLD position, so panning the molecule with grip
-    // brings the labels along but doesn't rescale them.
+    // Keep the world-locked narrative brief attached to the pivot's WORLD
+    // position so panning the molecule with grip brings the brief along
+    // but doesn't rescale it. Readout is now HUD-locked (child of camera)
+    // and intentionally does NOT follow.
     if (!this.pivot) return;
     this._uiWorldAnchor.copy(this.pivot.position);
-    if (this.readout) this.readout.group.position.copy(this._uiWorldAnchor);
     if (this.narrativePanel) this.narrativePanel.group.position.copy(this._uiWorldAnchor);
   }
 
@@ -399,6 +456,18 @@ export default class LevelOneScene {
   }
 
   destroy() {
+    // HUD readout is parented to the camera, not the scene — explicit detach
+    // so it doesn't survive into the next scene.
+    if (this.readout?.group?.parent) {
+      this.readout.group.parent.remove(this.readout.group);
+      this.readout.group.traverse?.((c) => {
+        if (c.geometry) c.geometry.dispose();
+        if (c.material) {
+          if (Array.isArray(c.material)) c.material.forEach((m) => m.dispose());
+          else c.material.dispose();
+        }
+      });
+    }
     for (const obj of this.objects) {
       this.ctx.scene.remove(obj);
       obj.traverse?.((c) => {

--- a/src/scenes/LevelOneScene.js
+++ b/src/scenes/LevelOneScene.js
@@ -113,6 +113,11 @@ export default class LevelOneScene {
     this.dtSinceInit = 0;
     this.redockCount = 0;
     this.lastButtons = { A: false, B: false }; // edge detection on left controller
+    // Scene-manager callback. Must be `null` (not undefined) so main.js's
+    // loadScene() wires it: `if (next.onComplete !== undefined) next.onComplete = ...`.
+    // Without this the dock-success transition silently no-ops.
+    this.onComplete = null;
+    this._completeTimer = null;
     // Two-handed grip gesture state — single grip = translate pivot,
     // both grips = bimanual scale + translate (Nanome-style).
     this._gripState = {

--- a/src/scenes/LevelOneScene.js
+++ b/src/scenes/LevelOneScene.js
@@ -15,6 +15,15 @@ const NARRATIVE_PATH = '/src/data/l1-narrative.json';
 const SPAWN_OFFSET = new THREE.Vector3(0.6, 0.0, 0.0); // ≥ 6 Å along +x relative to pocket
 const TELEMETRY_INTERVAL_MS = 1000;
 const BEST_POSE_BADGE_FADE_MS = 5000;
+// PyMOL exports geometry in Å (1 unit = 1 Å). At unit Three scale a 5 nm
+// protein renders 50 m wide and the user is inside the molecule. Scale the
+// whole pivot down so the protein sits desk-sized in front of the user.
+// User can grip-bimanual to rescale.
+const PIVOT_SCALE = 0.025;
+// Grip gesture limits — see [[experience-vr-scene-transition-tutorial-snap-patterns-2026-04-25]]
+// + [[prior-art-nanome]] (bimanual scale is the muscle memory we steal).
+const PIVOT_SCALE_MIN = 0.005;
+const PIVOT_SCALE_MAX = 0.20;
 
 const TELEMETRY_ENDPOINT = '/api/telemetry';
 
@@ -48,6 +57,19 @@ export default class LevelOneScene {
     this.dtSinceInit = 0;
     this.redockCount = 0;
     this.lastButtons = { A: false, B: false }; // edge detection on left controller
+    // Two-handed grip gesture state — single grip = translate pivot,
+    // both grips = bimanual scale + translate (Nanome-style).
+    this._gripState = {
+      active: 0,                  // 0, 1, or 2
+      handStart: null,            // Vec3 when single-grip started
+      pivotPosStart: null,
+      pivotScaleStart: null,
+      bimanualDistStart: null,
+      bimanualMidStart: null,
+    };
+    // World-locked UI anchor (kept separate from pivot so brief / readout
+    // stay readable regardless of model scale).
+    this._uiWorldAnchor = new THREE.Vector3();
   }
 
   async init() {
@@ -71,11 +93,14 @@ export default class LevelOneScene {
 
     const pocketCenter = new THREE.Vector3(...pocket.pocket_center);
 
-    // Centre everything around pocket so the user starts looking at the action.
+    // Pivot holds the protein + ligand. Scale it down so the user sees the
+    // whole molecule in front of them rather than being inside it.
     const pivot = new THREE.Group();
     pivot.position.set(0, 1.0, -0.8); // 0.8 m forward of player at standing height
+    pivot.scale.setScalar(PIVOT_SCALE);
     this.ctx.scene.add(pivot);
     this.objects.push(pivot);
+    this._uiWorldAnchor.copy(pivot.position);
 
     const offsetMatrix = new THREE.Matrix4().makeTranslation(
       -pocketCenter.x, -pocketCenter.y, -pocketCenter.z
@@ -96,36 +121,32 @@ export default class LevelOneScene {
       quaternion: ligand.quaternion.clone(),
     };
 
-    // Score readout above the pocket (in pivot-local coords -> already centred at origin).
-    // Camera is null at init time; update() re-binds it once XR session starts.
+    // Score readout — world-locked, NOT inside pivot, so it stays full-size
+    // when the user rescales the protein with bimanual grip.
     this.readout = buildReadout({
       pocketCenter: { x: 0, y: 0, z: 0 },
       camera: null,
     });
-    pivot.add(this.readout.group);
+    this.readout.group.position.copy(this._uiWorldAnchor);
+    this.ctx.scene.add(this.readout.group);
+    this.objects.push(this.readout.group);
 
-    // Narrative panel
+    // Narrative panel — also world-locked. Skip residue side-notes for now;
+    // attaching them in pivot-local frame would also shrink them, and the
+    // task brief is the critical onboarding text.
     this.narrativePanel = buildNarrativePanel({
       pocketCenter: { x: 0, y: 0, z: 0 },
-      pocketAnnotation: {
-        ...pocket,
-        // Shift residue Cα to pivot-local frame
-        key_residues: (pocket.key_residues || []).map((r) => ({
-          ...r,
-          ca_xyz: [r.ca_xyz[0] - pocketCenter.x, r.ca_xyz[1] - pocketCenter.y, r.ca_xyz[2] - pocketCenter.z],
-          side_chain_centroid: [
-            r.side_chain_centroid[0] - pocketCenter.x,
-            r.side_chain_centroid[1] - pocketCenter.y,
-            r.side_chain_centroid[2] - pocketCenter.z,
-          ],
-        })),
-      },
+      pocketAnnotation: { ...pocket, key_residues: [] },
       narrative,
       scoreReadoutAnchor: { x: 0, y: 0.5, z: 0 },
     });
-    pivot.add(this.narrativePanel.group);
+    this.narrativePanel.group.position.copy(this._uiWorldAnchor);
+    this.ctx.scene.add(this.narrativePanel.group);
+    this.objects.push(this.narrativePanel.group);
 
     this.pivot = pivot;
+    // Spawn farther back so the user actually sees the whole protein.
+    this.spawn = { player: [0, 0, 1.0], camera: [0, 1.6, 1.6] };
     this.ready = true;
 
     // Snapshot current A/B state so a held button doesn't produce a phantom
@@ -253,6 +274,85 @@ export default class LevelOneScene {
     }
 
     this._handleLeftControllerButtons(controllers);
+    this._handleGripGestures(controllers);
+  }
+
+  _handleGripGestures(controllers) {
+    const session = this.ctx.renderer.xr.getSession();
+    if (!session) return;
+
+    let leftDown = false, rightDown = false;
+    let leftPos = null, rightPos = null;
+
+    let idx = 0;
+    for (const src of session.inputSources) {
+      if (!src.gamepad || !src.handedness) { idx++; continue; }
+      const gripPressed = !!src.gamepad.buttons?.[1]?.pressed; // index 1 = squeeze/grip
+      const ctrl = controllers[idx];
+      if (!ctrl) { idx++; continue; }
+      const pos = new THREE.Vector3();
+      ctrl.getWorldPosition(pos);
+      if (src.handedness === 'left') {
+        leftDown = gripPressed;
+        leftPos = pos;
+      } else if (src.handedness === 'right') {
+        rightDown = gripPressed;
+        rightPos = pos;
+      }
+      idx++;
+    }
+
+    const numActive = (leftDown ? 1 : 0) + (rightDown ? 1 : 0);
+    const s = this._gripState;
+
+    if (numActive === 0) {
+      s.active = 0;
+      return;
+    }
+
+    if (numActive === 1) {
+      const handPos = leftDown ? leftPos : rightPos;
+      if (s.active !== 1) {
+        s.active = 1;
+        s.handStart = handPos.clone();
+        s.pivotPosStart = this.pivot.position.clone();
+      } else {
+        const delta = handPos.clone().sub(s.handStart);
+        this.pivot.position.copy(s.pivotPosStart).add(delta);
+        this._syncUiAnchor();
+      }
+    } else {
+      // Two-handed grip — bimanual scale + translate around the midpoint.
+      const currentDist = leftPos.distanceTo(rightPos);
+      const currentMid = leftPos.clone().add(rightPos).multiplyScalar(0.5);
+      if (s.active !== 2) {
+        s.active = 2;
+        s.bimanualDistStart = currentDist;
+        s.bimanualMidStart = currentMid.clone();
+        s.pivotScaleStart = this.pivot.scale.x;
+        s.pivotPosStart = this.pivot.position.clone();
+      } else {
+        const ratio = currentDist / Math.max(0.05, s.bimanualDistStart);
+        const newScale = Math.max(
+          PIVOT_SCALE_MIN,
+          Math.min(PIVOT_SCALE_MAX, s.pivotScaleStart * ratio),
+        );
+        this.pivot.scale.setScalar(newScale);
+        const midDelta = currentMid.clone().sub(s.bimanualMidStart);
+        this.pivot.position.copy(s.pivotPosStart).add(midDelta);
+        this._syncUiAnchor();
+      }
+    }
+  }
+
+  _syncUiAnchor() {
+    // Keep the world-locked UI (score readout + narrative brief) attached
+    // to the pivot's WORLD position, so panning the molecule with grip
+    // brings the labels along but doesn't rescale them.
+    if (!this.pivot) return;
+    this._uiWorldAnchor.copy(this.pivot.position);
+    if (this.readout) this.readout.group.position.copy(this._uiWorldAnchor);
+    if (this.narrativePanel) this.narrativePanel.group.position.copy(this._uiWorldAnchor);
   }
 
   _handleLeftControllerButtons(controllers) {

--- a/src/scenes/LevelOneScene.js
+++ b/src/scenes/LevelOneScene.js
@@ -24,8 +24,27 @@ const PIVOT_SCALE = 0.015;
 // + [[prior-art-nanome]] (bimanual scale is the muscle memory we steal).
 const PIVOT_SCALE_MIN = 0.005;
 const PIVOT_SCALE_MAX = 0.20;
+// 1:1 wrist rotation looks subtle on a heavily scaled-down protein, so
+// amplify the rotational delta only (translation stays 1:1 to keep the
+// "grab the world" metaphor honest).
+const ROTATION_GAIN = 2.5;
 
 const TELEMETRY_ENDPOINT = '/api/telemetry';
+
+// Stretch the angle of a quaternion by a gain factor (preserves axis).
+// Used to amplify wrist rotation when scaling pivot rotation in grip mode.
+function _amplifyQuat(delta, gain) {
+  const w = Math.max(-1, Math.min(1, delta.w));
+  const halfAngle = Math.acos(w);
+  if (halfAngle < 1e-4) return new THREE.Quaternion();
+  const sinHalf = Math.sin(halfAngle);
+  const ax = delta.x / sinHalf;
+  const ay = delta.y / sinHalf;
+  const az = delta.z / sinHalf;
+  const newHalf = halfAngle * gain;
+  const sinNew = Math.sin(newHalf);
+  return new THREE.Quaternion(ax * sinNew, ay * sinNew, az * sinNew, Math.cos(newHalf));
+}
 
 async function postTelemetry(events) {
   try {
@@ -312,25 +331,35 @@ export default class LevelOneScene {
     }
 
     if (numActive === 1) {
-      // Single-hand grip = 6-DOF "grab the world": pivot follows the
-      // controller's full pose (translate + rotate). Snapshot the relative
-      // pose at grip-start; each frame reapply it so pivot rides on the
-      // controller without ever physically reparenting (which would mess
-      // with the ligand's grabbable child).
+      // Single-hand grip — translate pivot 1:1 with hand position, rotate
+      // by amplified controller rotation around the pivot's own centre.
+      // Decoupled rather than matrix-relative so we can apply ROTATION_GAIN
+      // to rotation only — pure 6-DOF follow felt unresponsive on a
+      // 0.015-scaled protein.
       const ctrl = leftDown ? leftCtrl : rightCtrl;
       if (!ctrl) return;
+      const ctrlPos = new THREE.Vector3();
+      const ctrlQuat = new THREE.Quaternion();
+      ctrl.getWorldPosition(ctrlPos);
+      ctrl.getWorldQuaternion(ctrlQuat);
+
       if (s.active !== 1) {
         s.active = 1;
-        // relMat = ctrlWorld⁻¹ · pivotWorld
-        const ctrlInv = ctrl.matrixWorld.clone().invert();
-        s.relPivotMat = ctrlInv.multiply(this.pivot.matrixWorld);
+        s.ctrlStartPos = ctrlPos.clone();
+        s.ctrlStartQuat = ctrlQuat.clone();
+        s.pivotStartPos = this.pivot.position.clone();
+        s.pivotStartQuat = this.pivot.quaternion.clone();
       } else {
-        // pivot.world = ctrlWorld · relMat   (preserve current scale)
-        const newMat = ctrl.matrixWorld.clone().multiply(s.relPivotMat);
-        const _scale = new THREE.Vector3();
-        newMat.decompose(this.pivot.position, this.pivot.quaternion, _scale);
-        // _scale is the snapshot scale; we leave pivot.scale untouched so
-        // bimanual scale that may have happened earlier is preserved.
+        // Translate 1:1 with the hand
+        const deltaPos = ctrlPos.clone().sub(s.ctrlStartPos);
+        this.pivot.position.copy(s.pivotStartPos).add(deltaPos);
+
+        // Amplify rotation: convert delta to axis-angle, scale angle by
+        // ROTATION_GAIN, rebuild quaternion, prepend to pivot start.
+        const deltaQuat = ctrlQuat.clone().multiply(s.ctrlStartQuat.clone().invert());
+        const amp = _amplifyQuat(deltaQuat, ROTATION_GAIN);
+        this.pivot.quaternion.copy(s.pivotStartQuat).premultiply(amp);
+
         this._syncUiAnchor();
       }
     } else {

--- a/src/scenes/LevelTwoScene.js
+++ b/src/scenes/LevelTwoScene.js
@@ -46,9 +46,15 @@ const PROTEIN_COLOR = 0x88aaff;
 // = 0.015 this is 0.09 m world = ~ a fist's reach.
 const DOCK_TOLERANCE = 6.0;
 
-const PED_RADIUS = 0.7;
-const PED_ARC    = Math.PI * 0.55;
-const PED_HEIGHT = 0.85;
+// Pedestal arc layout — placed in front of the user but well clear of the
+// protein pivot (which sits at z=-0.8). Arc Z anchored at +0.5 puts the
+// ligand pedestals on the user's side of the room rather than embedded in
+// the protein hull.
+const PED_RADIUS    = 0.55;
+const PED_ARC       = Math.PI * 0.55;
+const PED_HEIGHT    = 0.85;
+const PED_ARC_Z_BASE = 0.50;
+const PED_ARC_Z_DEPTH = 0.25;
 
 const LIGAND_HANDHELD_SCALE = 0.018; // ligand GLB Å → world m
 
@@ -217,7 +223,7 @@ export default class LevelTwoScene {
       const t = ligands.length === 1 ? 0.5 : i / (ligands.length - 1);
       const angle = -PED_ARC / 2 + PED_ARC * t;
       const x = Math.sin(angle) * PED_RADIUS;
-      const z = -0.2 - Math.cos(angle) * 0.30;
+      const z = PED_ARC_Z_BASE - Math.cos(angle) * PED_ARC_Z_DEPTH;
 
       const group = new THREE.Group();
       group.position.set(x, 0, z);

--- a/src/scenes/LevelTwoScene.js
+++ b/src/scenes/LevelTwoScene.js
@@ -671,9 +671,51 @@ export default class LevelTwoScene {
       level: 'L2',
       ts: Date.now(),
     }]);
+    // No auto-transition: surface a persistent "Trigger to return" prompt
+    // once the success-card fade-out finishes; user dismisses on their own.
     this._completeTimer = setTimeout(() => {
-      if (this.onComplete) this.onComplete();
-    }, 3500);
+      this._showReturnPrompt();
+    }, 3300);
+  }
+
+  _showReturnPrompt() {
+    if (this._returnPrompt) return;
+    const canvas = document.createElement('canvas');
+    canvas.width = 1024; canvas.height = 256;
+    const ctx = canvas.getContext('2d');
+    ctx.fillStyle = 'rgba(8, 12, 28, 0.92)';
+    ctx.beginPath();
+    ctx.roundRect(0, 0, 1024, 256, 28);
+    ctx.fill();
+    ctx.fillStyle = '#06d6a0';
+    ctx.font = 'bold 64px ui-sans-serif, system-ui, sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText('Pull TRIGGER to return', 512, 100);
+    ctx.fillStyle = '#aaaacc';
+    ctx.font = '36px ui-sans-serif, system-ui, sans-serif';
+    ctx.fillText('to the level menu', 512, 170);
+    const tex = new THREE.CanvasTexture(canvas);
+    tex.colorSpace = THREE.SRGBColorSpace;
+    const mesh = new THREE.Mesh(
+      new THREE.PlaneGeometry(0.8, 0.20),
+      new THREE.MeshBasicMaterial({
+        map: tex, transparent: true, depthTest: false, depthWrite: false,
+      })
+    );
+    mesh.position.set(0, -0.15, -1.2);
+    mesh.renderOrder = 999;
+    this.ctx.camera.add(mesh);
+    this._returnPrompt = mesh;
+  }
+
+  // Public hook used by main.js's onSelectStart fallback (same contract as
+  // GameHubScene._onControllerClick): if all five ligands are docked and
+  // the user pulls trigger anywhere, return them to the level menu.
+  _onControllerClick(/* controller */) {
+    if (this.completed && this.onComplete) {
+      this.onComplete();
+    }
   }
 
   _handleLeftA(controllers) {
@@ -805,6 +847,14 @@ export default class LevelTwoScene {
       this.successCard.parent.remove(this.successCard);
       if (this.successCard.geometry) this.successCard.geometry.dispose();
       if (this.successCard.material) this.successCard.material.dispose();
+    }
+    if (this._returnPrompt?.parent) {
+      this._returnPrompt.parent.remove(this._returnPrompt);
+      if (this._returnPrompt.geometry) this._returnPrompt.geometry.dispose();
+      if (this._returnPrompt.material) {
+        if (this._returnPrompt.material.map) this._returnPrompt.material.map.dispose();
+        this._returnPrompt.material.dispose();
+      }
     }
 
     for (const obj of this.objects) {

--- a/src/scenes/LevelTwoScene.js
+++ b/src/scenes/LevelTwoScene.js
@@ -40,6 +40,10 @@ const PIVOT_SCALE     = 0.015;
 const PIVOT_SCALE_MIN = 0.005;
 const PIVOT_SCALE_MAX = 0.20;
 const ROTATION_GAIN   = 2.5;
+// Pivot translation amplification — heavily-scaled-down protein at 1:1 hand
+// mapping feels sluggish to drag across the room; 2.0× makes a small wrist
+// motion meaningfully relocate the molecule.
+const TRANSLATION_GAIN = 2.0;
 
 const PROTEIN_COLOR = 0x88aaff;
 // Drop tolerance in pivot-local Å (PyMOL geometry units). At PIVOT_SCALE
@@ -396,29 +400,28 @@ export default class LevelTwoScene {
     const entry = this.barChart.bars.find((b) => b.lig.name === ligandName);
     if (!entry) return;
     const { bar, fullHeight, baseY, valueLabel, valueCanvas, valueTex } = entry;
-    const startTime = performance.now();
-    const duration = 600;
-    const tick = () => {
-      const t = Math.min(1, (performance.now() - startTime) / duration);
-      const eased = 1 - (1 - t) * (1 - t);
-      bar.scale.y = Math.max(0.0001, fullHeight * eased);
-      bar.position.y = baseY + (fullHeight * eased) / 2;
-      bar.material.opacity = 0.85 * eased;
-      if (t < 1) requestAnimationFrame(tick);
-      else {
-        const ctx = valueCanvas.getContext('2d');
-        ctx.clearRect(0, 0, 256, 64);
-        ctx.fillStyle = '#ffffff';
-        ctx.font = 'bold 40px ui-sans-serif, system-ui, sans-serif';
-        ctx.textAlign = 'center';
-        ctx.textBaseline = 'middle';
-        ctx.fillText(`${vinaKcal.toFixed(1)}`, 128, 32);
-        valueTex.needsUpdate = true;
-        valueLabel.position.y = baseY + fullHeight + 0.03;
-        valueLabel.visible = true;
-      }
-    };
-    tick();
+
+    // Set the final visual state immediately. The previous version drove
+    // the bar-fill animation off `requestAnimationFrame`, but `window.rAF`
+    // is paused during a WebXR `immersive-vr` session on Quest, so the
+    // animation never reached its terminal state and the ΔG value label
+    // stayed hidden. Skip the animation; the bar simply pops to full
+    // height with the value rendered (the dock-success haptic + pedestal
+    // ring colour change carry the moment).
+    bar.scale.y = Math.max(0.0001, fullHeight);
+    bar.position.y = baseY + fullHeight / 2;
+    bar.material.opacity = 0.85;
+
+    const ctx = valueCanvas.getContext('2d');
+    ctx.clearRect(0, 0, 256, 64);
+    ctx.fillStyle = '#ffffff';
+    ctx.font = 'bold 40px ui-sans-serif, system-ui, sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(`${vinaKcal.toFixed(1)}`, 128, 32);
+    valueTex.needsUpdate = true;
+    valueLabel.position.y = baseY + fullHeight + 0.03;
+    valueLabel.visible = true;
   }
 
   _buildHud(data) {
@@ -723,7 +726,9 @@ export default class LevelTwoScene {
         s.pivotStartPos = this.pivot.position.clone();
         s.pivotStartQuat = this.pivot.quaternion.clone();
       } else {
-        const deltaPos = ctrlPos.clone().sub(s.ctrlStartPos);
+        // Translation amplified so a small hand motion meaningfully drags
+        // the (heavily down-scaled) protein across the bench.
+        const deltaPos = ctrlPos.clone().sub(s.ctrlStartPos).multiplyScalar(TRANSLATION_GAIN);
         this.pivot.position.copy(s.pivotStartPos).add(deltaPos);
         const deltaQuat = ctrlQuat.clone().multiply(s.ctrlStartQuat.clone().invert());
         const amp = _amplifyQuat(deltaQuat, ROTATION_GAIN);
@@ -749,7 +754,7 @@ export default class LevelTwoScene {
           Math.min(PIVOT_SCALE_MAX, s.pivotScaleStart * ratio)
         );
         this.pivot.scale.setScalar(newScale);
-        const midDelta = currentMid.clone().sub(s.bimanualMidStart);
+        const midDelta = currentMid.clone().sub(s.bimanualMidStart).multiplyScalar(TRANSLATION_GAIN);
         this.pivot.position.copy(s.pivotPosStart).add(midDelta);
         this._syncUiAnchor();
       }

--- a/src/scenes/LevelTwoScene.js
+++ b/src/scenes/LevelTwoScene.js
@@ -1,28 +1,56 @@
 // src/scenes/LevelTwoScene.js
 //
-// Level 2 (F-005): rank 5 NSAID analogs against COX-2 by predicted Vina ΔG.
-// Lifecycle matches LevelOneScene: init / update(dt, controllers) /
-// destroy / getGrabbables.
+// Level 2 (F-005): rank 5 NSAID analogs by docking each into COX-2.
 //
-// UX: 5 pedestals in an arc. Triggering / clicking a pedestal reveals that
-// ligand's bar on a VR bar chart plus a narrative card explaining its
-// H-bond and hydrophobic contributions. Level completes once every pedestal
-// has been activated.
+// Spec (Issue #10 / hackathon-mvp-design.md):
+//   - COX-2 + 5 ligand 选择面板
+//   - 每个 ligand dock 后输出 score
+//   - VR-native bar chart 展示 5 个 affinity 排名
+//   - 排名顺序与 Vina ground truth 一致
+//   - Narrative card：H-bond / hydrophobic 贡献分解说明
+//
+// UX:
+//   1. COX-2 protein at centre, scaled small, with grip translate / rotate /
+//      bimanual-scale (same gestures as L1).
+//   2. Five colour-coded ligand pedestals fanned out in front of the user.
+//      Each pedestal carries a real ligand GLB (celecoxib, rofecoxib,
+//      diclofenac, naproxen, ibuprofen) that is grabbable with the trigger.
+//   3. User trigger-grabs a ligand off its pedestal, drags it into the
+//      glowing green pocket sphere on the protein. When the ligand crosses
+//      `DOCK_TOLERANCE` (Å, in pivot-local frame), the dock fires:
+//      - the ligand snaps back to its pedestal as a green-emissive "done"
+//        marker (no longer grabbable);
+//      - that ligand's bar in the chart fills with its Vina ΔG (ground truth);
+//      - haptic burst on both controllers.
+//   4. After all five are docked, an "ALL FIVE DOCKED!" success card fades
+//      in/out for 3.2 s and the level transitions back to the hub.
+//
+// HUD bundle = camera child with the progress readout above and the brief
+// panel below, identical pattern to L1.
 
 import * as THREE from 'three';
-import { loadJSON } from '../lib/asset-loader.js';
+import { loadGLB, loadJSON } from '../lib/asset-loader.js';
+import { buildNarrativePanel } from '../ui/narrative-panel.js';
 
-const DATA_PATH = '/src/data/l2-data.json';
+const ASSET_BASE = '/assets/v1';
+const DATA_PATH  = '/src/data/l2-data.json';
 const TELEMETRY_ENDPOINT = '/api/telemetry';
-const TELEMETRY_INTERVAL_MS = 1000;
 
-const HUB_CENTER = new THREE.Vector3(0, 1.0, -1.4);
-const PEDESTAL_RADIUS = 1.2;
-const BAR_CHART_POSITION = new THREE.Vector3(0, 1.6, -2.6);
-const BAR_CHART_WIDTH = 1.6;
-const BAR_CHART_HEIGHT = 0.8;
-const NARRATIVE_POSITION = new THREE.Vector3(0, 2.4, -2.6);
-const BRIEF_POSITION = new THREE.Vector3(0, 2.4, -1.4);
+const PIVOT_SCALE     = 0.015;
+const PIVOT_SCALE_MIN = 0.005;
+const PIVOT_SCALE_MAX = 0.20;
+const ROTATION_GAIN   = 2.5;
+
+const PROTEIN_COLOR = 0x88aaff;
+// Drop tolerance in pivot-local Å (PyMOL geometry units). At PIVOT_SCALE
+// = 0.015 this is 0.09 m world = ~ a fist's reach.
+const DOCK_TOLERANCE = 6.0;
+
+const PED_RADIUS = 0.7;
+const PED_ARC    = Math.PI * 0.55;
+const PED_HEIGHT = 0.85;
+
+const LIGAND_HANDHELD_SCALE = 0.018; // ligand GLB Å → world m
 
 async function postTelemetry(events) {
   try {
@@ -31,549 +59,709 @@ async function postTelemetry(events) {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(events),
     });
-  } catch (err) {
-    console.warn('[L2 telemetry]', err);
-  }
+  } catch (err) { console.warn('[L2 telemetry]', err); }
 }
 
-function hexFromString(s) {
-  return parseInt(s, 16);
+// ---- shared helpers (same shape as LevelOneScene) -----------------------
+
+function _amplifyQuat(delta, gain) {
+  const w = Math.max(-1, Math.min(1, delta.w));
+  const halfAngle = Math.acos(w);
+  if (halfAngle < 1e-4) return new THREE.Quaternion();
+  const sinHalf = Math.sin(halfAngle);
+  const ax = delta.x / sinHalf;
+  const ay = delta.y / sinHalf;
+  const az = delta.z / sinHalf;
+  const newHalf = halfAngle * gain;
+  const sinNew = Math.sin(newHalf);
+  return new THREE.Quaternion(ax * sinNew, ay * sinNew, az * sinNew, Math.cos(newHalf));
+}
+
+function _recolor(root, hex, opts = {}) {
+  const { emissiveIntensity = 0.0, transparent = false, opacity = 1.0 } = opts;
+  root.traverse((c) => {
+    if (!c.material) return;
+    const list = Array.isArray(c.material) ? c.material : [c.material];
+    const cloned = list.map((m) => {
+      const cm = m.clone();
+      if (cm.color) cm.color.setHex(hex);
+      if (cm.emissive) {
+        cm.emissive.setHex(hex);
+        cm.emissiveIntensity = emissiveIntensity;
+      }
+      cm.transparent = transparent || cm.transparent;
+      if (transparent) cm.opacity = opacity;
+      return cm;
+    });
+    c.material = Array.isArray(c.material) ? cloned : cloned[0];
+  });
 }
 
 export default class LevelTwoScene {
   constructor(ctx) {
     this.ctx = ctx;
     this.objects = [];
-    this.pedestals = [];
-    this.activated = new Set();
-    this.data = null;
-    this.barChart = null;
-    this.narrativePanel = null;
-    this.briefPanel = null;
+    this.ready = false;
     this.completed = false;
     this.onComplete = null;
+    this._completeTimer = null;
+
+    this.pedestals  = [];
+    this.activated  = new Set();
+    this.barChart   = null;
+    this.successCard = null;
+
+    this.lastButtons = { A: false };
     this.telemetryAccumMs = 0;
-    // Map<handedness, boolean> — keyed by 'left'/'right' so inputSources
-    // order swaps (controller↔hand handover) don't break edge detection.
-    this._prevSelect = new Map();
-    this._desktopClick = null;
-    this.spawn = { player: [0, 0, 0], camera: [0, 1.6, 0.6] };
+
+    this._gripState     = { active: 0 };
+    this._uiWorldAnchor = new THREE.Vector3();
+
+    this.spawn = { player: [0, 0, 1.5], camera: [0, 1.6, 2.2] };
   }
 
   async init() {
-    this.data = await loadJSON(DATA_PATH);
-
-    this._buildEnvironment();
-    this._buildPedestals();
-    this._buildBarChart();
-    this._buildNarrativePanel();
-    this._buildBriefPanel();
-
-    // Snapshot current trigger state so a held-from-hub trigger doesn't
-    // produce a phantom first-frame selection here.
-    this._snapshotTriggers();
-
-    postTelemetry([
-      {
-        session_id: window.__VDV_SESSION_ID || crypto.randomUUID(),
-        event_type: 'level_start',
-        level: 'L2',
-        target: 'cox2',
-        ts: Date.now(),
-      },
+    const [cox2Surface, cox2Cartoon, pocket, vina, data, ...ligandMeshes] = await Promise.all([
+      loadGLB(`${ASSET_BASE}/cox2_surface.glb`),
+      loadGLB(`${ASSET_BASE}/cox2_cartoon.glb`),
+      loadJSON(`${ASSET_BASE}/pocket_cox2.json`),
+      loadJSON(`${ASSET_BASE}/vina_results.json`),
+      loadJSON(DATA_PATH),
+      // Ligand GLBs in fixed order matching l2-data.json's ligands array.
+      // Loaded eagerly so the grab path is ready immediately.
+      loadGLB(`${ASSET_BASE}/ligands/celecoxib.glb`),
+      loadGLB(`${ASSET_BASE}/ligands/rofecoxib.glb`),
+      loadGLB(`${ASSET_BASE}/ligands/diclofenac.glb`),
+      loadGLB(`${ASSET_BASE}/ligands/naproxen.glb`),
+      loadGLB(`${ASSET_BASE}/ligands/ibuprofen.glb`),
     ]);
+
+    this.pocket = pocket;
+    this.vinaResults = vina.runs;
+    this.data = data;
+
+    const pocketCenter = new THREE.Vector3(...pocket.pocket_center);
+    this.pocketCenter = pocketCenter;
+
+    // ---- Protein pivot ------------------------------------------------
+    const pivot = new THREE.Group();
+    pivot.position.set(0, 1.0, -0.8);
+    pivot.scale.setScalar(PIVOT_SCALE);
+    this.ctx.scene.add(pivot);
+    this.objects.push(pivot);
+    this._uiWorldAnchor.copy(pivot.position);
+
+    const offsetMatrix = new THREE.Matrix4().makeTranslation(
+      -pocketCenter.x, -pocketCenter.y, -pocketCenter.z
+    );
+    cox2Surface.applyMatrix4(offsetMatrix);
+    cox2Cartoon.applyMatrix4(offsetMatrix);
+    _recolor(cox2Surface, PROTEIN_COLOR, { transparent: true, opacity: 0.55 });
+    _recolor(cox2Cartoon, PROTEIN_COLOR, { emissiveIntensity: 0.15 });
+    pivot.add(cox2Surface);
+    pivot.add(cox2Cartoon);
+    this.pivot = pivot;
+
+    // Glowing green pocket-sphere — the visible "drop here" target.
+    this._buildPocketTarget(pivot);
+
+    // ---- Ligand pedestals (synced order with the loaded GLBs above) ---
+    const ligandsByName = {
+      celecoxib:  ligandMeshes[0],
+      rofecoxib:  ligandMeshes[1],
+      diclofenac: ligandMeshes[2],
+      naproxen:   ligandMeshes[3],
+      ibuprofen:  ligandMeshes[4],
+    };
+    this._buildLigandPedestals(data.ligands, ligandsByName);
+
+    // ---- Bar chart (world-locked, behind protein) --------------------
+    this._buildBarChart(data.ligands);
+
+    // ---- HUD bundle (camera-child progress + brief) ------------------
+    this._buildHud(data);
+
+    // ---- Success card (camera-child, hidden until all 5 docked) ------
+    this._buildSuccessCard();
+
+    this.ready = true;
+    postTelemetry([{
+      session_id: window.__VDV_SESSION_ID || 'anon',
+      event_type: 'level_start',
+      level: 'L2',
+      target: 'cox2',
+      ts: Date.now(),
+    }]);
   }
 
-  _snapshotTriggers() {
-    const session = this.ctx.renderer.xr.getSession();
-    if (!session) return;
-    for (const src of session.inputSources) {
-      if (!src.handedness || !src.gamepad) continue;
-      this._prevSelect.set(src.handedness, !!src.gamepad.buttons?.[0]?.pressed);
-    }
+  _buildPocketTarget(pivot) {
+    const sphereGeo = new THREE.SphereGeometry(DOCK_TOLERANCE, 24, 16);
+    const sphereMat = new THREE.MeshBasicMaterial({
+      color: 0x06d6a0,
+      transparent: true,
+      opacity: 0.22,
+      depthWrite: false,
+    });
+    const sphere = new THREE.Mesh(sphereGeo, sphereMat);
+    sphere.position.set(0, 0, 0); // pivot-local pocket centre (geometry was offset)
+    pivot.add(sphere);
+    this.pocketTarget = sphere;
   }
 
-  // ---- environment --------------------------------------------------------
-
-  _buildEnvironment() {
-    const platGeo = new THREE.CylinderGeometry(2.0, 2.2, 0.08, 48);
-    const platMat = new THREE.MeshStandardMaterial({ color: 0x14142a, roughness: 0.7, metalness: 0.2 });
-    const platform = new THREE.Mesh(platGeo, platMat);
-    platform.position.set(HUB_CENTER.x, 0.04, HUB_CENTER.z);
-    this._add(platform);
-  }
-
-  _buildPedestals() {
-    const ligands = this.data.ligands;
-    const arcStart = -0.5; // radians, leftmost
-    const arcEnd = 0.5;
-    const n = ligands.length;
-
-    for (let i = 0; i < n; i++) {
+  _buildLigandPedestals(ligands, ligandsByName) {
+    for (let i = 0; i < ligands.length; i++) {
       const lig = ligands[i];
-      const t = n === 1 ? 0.5 : i / (n - 1);
-      const angle = arcStart + (arcEnd - arcStart) * t;
-      const x = HUB_CENTER.x + Math.sin(angle) * PEDESTAL_RADIUS;
-      const z = HUB_CENTER.z + Math.cos(angle) * PEDESTAL_RADIUS - PEDESTAL_RADIUS;
+      const mesh = ligandsByName[lig.name];
+      if (!mesh) continue;
+
+      const t = ligands.length === 1 ? 0.5 : i / (ligands.length - 1);
+      const angle = -PED_ARC / 2 + PED_ARC * t;
+      const x = Math.sin(angle) * PED_RADIUS;
+      const z = -0.2 - Math.cos(angle) * 0.30;
 
       const group = new THREE.Group();
       group.position.set(x, 0, z);
 
-      const color = hexFromString(lig.color.replace('0x', ''));
+      const colorHex = parseInt(lig.color.replace('0x', ''), 16);
 
       // Pedestal column
-      const pedGeo = new THREE.CylinderGeometry(0.18, 0.22, 0.7, 24);
-      const pedMat = new THREE.MeshStandardMaterial({ color: 0x222244, roughness: 0.6, metalness: 0.3 });
-      const pedestal = new THREE.Mesh(pedGeo, pedMat);
-      pedestal.position.y = 0.35;
-      group.add(pedestal);
+      const col = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.06, 0.08, PED_HEIGHT, 16),
+        new THREE.MeshStandardMaterial({ color: 0x222244, roughness: 0.6 })
+      );
+      col.position.y = PED_HEIGHT / 2;
+      group.add(col);
 
-      // Molecule proxy (color-coded sphere with a smaller sphere "substituent")
-      const molGroup = new THREE.Group();
-      molGroup.position.y = 0.92;
-
-      const coreGeo = new THREE.IcosahedronGeometry(0.12, 1);
-      const coreMat = new THREE.MeshStandardMaterial({
-        color,
-        emissive: color,
-        emissiveIntensity: 0.25,
-        roughness: 0.4,
-        metalness: 0.4,
-      });
-      const core = new THREE.Mesh(coreGeo, coreMat);
-      molGroup.add(core);
-
-      // Add a few satellite atoms for visual variety
-      for (let j = 0; j < 4; j++) {
-        const angle = (j / 4) * Math.PI * 2;
-        const sat = new THREE.Mesh(
-          new THREE.IcosahedronGeometry(0.05, 0),
-          new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 0.5 })
-        );
-        sat.position.set(Math.cos(angle) * 0.18, Math.sin(angle * 0.5) * 0.06, Math.sin(angle) * 0.18);
-        molGroup.add(sat);
-      }
-
-      group.add(molGroup);
-
-      // Selection ring (highlights when activated)
-      const ringGeo = new THREE.RingGeometry(0.25, 0.3, 32);
+      // Coloured ring on top — turns green when ligand is docked
       const ringMat = new THREE.MeshBasicMaterial({
-        color,
-        transparent: true,
-        opacity: 0.4,
-        side: THREE.DoubleSide,
+        color: colorHex, transparent: true, opacity: 0.7, side: THREE.DoubleSide,
       });
-      const ring = new THREE.Mesh(ringGeo, ringMat);
+      const ring = new THREE.Mesh(new THREE.RingGeometry(0.07, 0.10, 24), ringMat);
       ring.rotation.x = -Math.PI / 2;
-      ring.position.y = 0.71;
+      ring.position.y = PED_HEIGHT + 0.01;
       group.add(ring);
 
-      // Name label
-      const label = this._createLabelSprite(lig.name, color);
-      label.position.set(0, 1.2, 0);
+      // Ligand GLB sitting on the pedestal — the grabbable
+      mesh.scale.setScalar(LIGAND_HANDHELD_SCALE);
+      _recolor(mesh, colorHex, { emissiveIntensity: 0.40 });
+      mesh.position.y = PED_HEIGHT + 0.10;
+      mesh.userData.grabbable = true;
+      mesh.userData.ligandId = lig.name;
+      mesh.userData.ligandData = lig;
+      mesh.userData.spawnPos = mesh.position.clone();
+      mesh.userData.spawnQuat = mesh.quaternion.clone();
+      mesh.userData.spawnScale = mesh.scale.clone();
+      mesh.userData.spawnParent = group;
+      group.add(mesh);
+
+      // Name label sprite above
+      const labelTex = this._makeLabelTexture(lig.name, colorHex);
+      const labelMat = new THREE.SpriteMaterial({
+        map: labelTex, transparent: true, depthTest: false,
+      });
+      const label = new THREE.Sprite(labelMat);
+      label.scale.set(0.20, 0.05, 1);
+      label.position.set(0, PED_HEIGHT + 0.28, 0);
       group.add(label);
 
       this._add(group);
       this.pedestals.push({
-        group,
+        group, mesh, ringMat,
         ligand: lig,
-        coreMat,
-        ringMat,
-        molGroup,
         idx: i,
       });
     }
   }
 
-  // ---- bar chart ----------------------------------------------------------
-
-  _buildBarChart() {
-    const ligands = this.data.ligands;
-    const group = new THREE.Group();
-    group.position.copy(BAR_CHART_POSITION);
-
-    // Background panel
-    const panelGeo = new THREE.PlaneGeometry(BAR_CHART_WIDTH, BAR_CHART_HEIGHT);
-    const panelMat = new THREE.MeshBasicMaterial({ color: 0x080c1c, transparent: true, opacity: 0.85, side: THREE.DoubleSide });
-    const panel = new THREE.Mesh(panelGeo, panelMat);
-    group.add(panel);
-
-    // Title sprite
-    const title = this._createTextSprite('COX-2 Vina ΔG (kcal/mol) — lower is tighter', '#9ad9ff', 28);
-    title.position.set(0, BAR_CHART_HEIGHT / 2 - 0.07, 0.005);
-    title.scale.set(BAR_CHART_WIDTH * 0.95, 0.07, 1);
-    group.add(title);
-
-    // Compute scaling: most negative score maps to max bar height
-    const minScore = Math.min(...ligands.map((l) => l.vina_kcal));
-    const maxBarHeight = BAR_CHART_HEIGHT * 0.65;
-    const innerWidth = BAR_CHART_WIDTH * 0.9;
-    const innerStart = -innerWidth / 2;
-    const slot = innerWidth / ligands.length;
-
-    const bars = [];
-    for (let i = 0; i < ligands.length; i++) {
-      const lig = ligands[i];
-      const fullHeight = maxBarHeight * (lig.vina_kcal / minScore);
-      const x = innerStart + slot * (i + 0.5);
-      const baseY = -BAR_CHART_HEIGHT / 2 + 0.18;
-
-      const color = hexFromString(lig.color.replace('0x', ''));
-
-      // Bar (initially hidden — height grows on activation)
-      const barMat = new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.0 });
-      const barGeo = new THREE.PlaneGeometry(slot * 0.55, 1);
-      const bar = new THREE.Mesh(barGeo, barMat);
-      bar.position.set(x, baseY, 0.003);
-      bar.scale.y = 0.0001; // hidden until activated
-      group.add(bar);
-
-      // Label below bar
-      const label = this._createTextSprite(lig.name, '#ffffff', 22);
-      label.position.set(x, baseY - 0.06, 0.005);
-      label.scale.set(slot * 0.95, 0.05, 1);
-      group.add(label);
-
-      // Value label (shown when activated)
-      const valueLabel = this._createTextSprite('', '#ffffff', 22);
-      valueLabel.position.set(x, 0, 0.005);
-      valueLabel.scale.set(slot * 0.95, 0.05, 1);
-      valueLabel.visible = false;
-      group.add(valueLabel);
-
-      bars.push({ bar, fullHeight, baseY, valueLabel, lig });
-    }
-
-    this._add(group);
-    this.barChart = { group, bars };
-  }
-
-  _revealBar(idx) {
-    const entry = this.barChart.bars[idx];
-    if (!entry) return;
-    const { bar, fullHeight, baseY, valueLabel, lig } = entry;
-
-    // Animate bar fill
-    const startTime = performance.now();
-    const duration = 600;
-    const animate = () => {
-      const t = Math.min(1, (performance.now() - startTime) / duration);
-      const eased = 1 - (1 - t) * (1 - t);
-      bar.scale.y = Math.max(0.0001, fullHeight * eased);
-      bar.position.y = baseY + (fullHeight * eased) / 2;
-      bar.material.opacity = 0.85 * eased;
-
-      if (t < 1) requestAnimationFrame(animate);
-      else {
-        // Show value
-        const tex = this._textTexture(lig.vina_kcal.toFixed(1), '#ffffff', 22);
-        valueLabel.material.map.dispose();
-        valueLabel.material.map = tex;
-        valueLabel.material.needsUpdate = true;
-        valueLabel.position.y = baseY + fullHeight + 0.04;
-        valueLabel.visible = true;
-      }
-    };
-    animate();
-  }
-
-  // ---- narrative panel ----------------------------------------------------
-
-  _buildNarrativePanel() {
-    const group = new THREE.Group();
-    group.position.copy(NARRATIVE_POSITION);
-
-    const w = 1.6;
-    const h = 0.5;
+  _makeLabelTexture(text, colorHex) {
     const canvas = document.createElement('canvas');
-    canvas.width = 1024;
-    canvas.height = 320;
-
-    const tex = new THREE.CanvasTexture(canvas);
-    tex.colorSpace = THREE.SRGBColorSpace;
-    const mat = new THREE.MeshBasicMaterial({ map: tex, transparent: true, side: THREE.DoubleSide });
-    const panel = new THREE.Mesh(new THREE.PlaneGeometry(w, h), mat);
-    group.add(panel);
-
-    this._add(group);
-    this.narrativePanel = { group, canvas, tex, panel };
-    this._paintNarrative(null);
-  }
-
-  _paintNarrative(ligand) {
-    const canvas = this.narrativePanel.canvas;
+    canvas.width = 512; canvas.height = 96;
     const ctx = canvas.getContext('2d');
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-
-    ctx.fillStyle = 'rgba(8, 12, 28, 0.92)';
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
-
-    if (!ligand) {
-      ctx.fillStyle = '#9ad9ff';
-      ctx.font = 'bold 36px ui-sans-serif, system-ui, sans-serif';
-      ctx.textBaseline = 'top';
-      ctx.fillText('Trigger any pedestal to reveal a ligand', 32, 32);
-
-      ctx.fillStyle = '#aaa';
-      ctx.font = '24px ui-sans-serif, system-ui, sans-serif';
-      ctx.fillText(this.data.score_hint, 32, 90);
-
-      ctx.fillStyle = '#ffd166';
-      ctx.font = '22px ui-sans-serif, system-ui, sans-serif';
-      ctx.fillText(`Activated ${this.activated.size}/${this.data.ligands.length}`, 32, canvas.height - 50);
-      this.narrativePanel.tex.needsUpdate = true;
-      return;
-    }
-
-    // Title row
-    ctx.fillStyle = '#9ad9ff';
-    ctx.font = 'bold 40px ui-sans-serif, system-ui, sans-serif';
-    ctx.textBaseline = 'top';
-    ctx.fillText(ligand.name, 32, 24);
-
-    // Score
-    ctx.fillStyle = '#ffd166';
-    ctx.font = 'bold 32px ui-monospace, monospace';
-    ctx.fillText(`ΔG = ${ligand.vina_kcal.toFixed(1)} kcal/mol`, 32, 80);
-
-    // H-bonds + hydrophobic
-    ctx.fillStyle = '#9ad9ff';
-    ctx.font = '22px ui-sans-serif, system-ui, sans-serif';
-    ctx.fillText(`H-bonds: ${ligand.h_bonds}     Hydrophobic burial: ${ligand.hydrophobic}`, 32, 130);
-
-    // Tagline (wrapped)
-    ctx.fillStyle = '#e0e0f0';
-    ctx.font = '22px ui-sans-serif, system-ui, sans-serif';
-    let y = 170;
-    for (const line of this._wrapText(ctx, ligand.tagline, canvas.width - 64)) {
-      ctx.fillText(line, 32, y);
-      y += 28;
-    }
-
-    // Activation counter
-    ctx.fillStyle = this.activated.size === this.data.ligands.length ? '#06d6a0' : '#ffd166';
-    ctx.font = '22px ui-sans-serif, system-ui, sans-serif';
-    ctx.fillText(
-      this.activated.size === this.data.ligands.length
-        ? '✓ All five ranked — level complete'
-        : `Activated ${this.activated.size}/${this.data.ligands.length}`,
-      32,
-      canvas.height - 50,
-    );
-
-    this.narrativePanel.tex.needsUpdate = true;
-  }
-
-  // ---- task brief ---------------------------------------------------------
-
-  _buildBriefPanel() {
-    const group = new THREE.Group();
-    group.position.copy(BRIEF_POSITION);
-
-    const w = 1.4;
-    const h = 0.5;
-    const canvas = document.createElement('canvas');
-    canvas.width = 1024;
-    canvas.height = 360;
-    const ctx = canvas.getContext('2d');
-    ctx.fillStyle = 'rgba(8, 12, 28, 0.92)';
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
-
-    ctx.fillStyle = '#9ad9ff';
-    ctx.font = 'bold 40px ui-sans-serif, system-ui, sans-serif';
-    ctx.textBaseline = 'top';
-    ctx.fillText(this.data.brief.title, 32, 24);
-
-    ctx.fillStyle = '#9ad9ff';
-    ctx.font = 'bold 22px ui-sans-serif, system-ui, sans-serif';
-    ctx.fillText('Biology', 32, 90);
-    ctx.fillStyle = '#e0e0f0';
-    ctx.font = '22px ui-sans-serif, system-ui, sans-serif';
-    let y = 120;
-    for (const line of this._wrapText(ctx, this.data.brief.biology, canvas.width - 64)) {
-      ctx.fillText(line, 32, y);
-      y += 28;
-    }
-    y += 10;
-
-    ctx.fillStyle = '#9ad9ff';
-    ctx.font = 'bold 22px ui-sans-serif, system-ui, sans-serif';
-    ctx.fillText('Engineering', 32, y);
-    y += 30;
-    ctx.fillStyle = '#e0e0f0';
-    ctx.font = '22px ui-sans-serif, system-ui, sans-serif';
-    for (const line of this._wrapText(ctx, this.data.brief.engineering, canvas.width - 64)) {
-      ctx.fillText(line, 32, y);
-      y += 28;
-    }
-
-    const tex = new THREE.CanvasTexture(canvas);
-    tex.colorSpace = THREE.SRGBColorSpace;
-    const mat = new THREE.MeshBasicMaterial({ map: tex, transparent: true, side: THREE.DoubleSide });
-    const panel = new THREE.Mesh(new THREE.PlaneGeometry(w, h), mat);
-    group.add(panel);
-    this._add(group);
-    this.briefPanel = { group, panel };
-  }
-
-  // ---- update loop --------------------------------------------------------
-
-  update(dt, controllers) {
-    this.telemetryAccumMs += dt;
-
-    // Idle rotation on molecule proxies for visual interest
-    const t = performance.now() * 0.001;
-    for (const ped of this.pedestals) {
-      ped.molGroup.rotation.y = t * 0.5;
-      // Pulse activated rings; fade unselected ones
-      if (this.activated.has(ped.idx)) {
-        ped.ringMat.opacity = 0.6 + Math.sin(t * 3 + ped.idx) * 0.15;
-      } else {
-        ped.ringMat.opacity = 0.4 + Math.sin(t * 1.5 + ped.idx) * 0.08;
-      }
-    }
-
-    this._handleSelections(controllers);
-
-    if (!this.completed && this.activated.size === this.data.ligands.length) {
-      this.completed = true;
-      postTelemetry([
-        {
-          session_id: window.__VDV_SESSION_ID || 'anon',
-          event_type: 'level_complete',
-          level: 'L2',
-          ts: Date.now(),
-        },
-      ]);
-      // Defer onComplete by a beat so the user sees the final reveal
-      setTimeout(() => {
-        if (this.onComplete) this.onComplete();
-      }, 1500);
-    }
-  }
-
-  _handleSelections(controllers) {
-    // VR triggers — key prev-state by handedness, not array index, so
-    // controller↔hand swaps mid-session don't desync edge detection.
-    const session = this.ctx.renderer.xr.getSession();
-    if (session) {
-      let idx = 0;
-      for (const source of session.inputSources) {
-        if (!source.handedness || !source.gamepad) { idx++; continue; }
-        const pressed = !!source.gamepad?.buttons?.[0]?.pressed;
-        const prev = this._prevSelect.get(source.handedness) ?? false;
-        const fresh = pressed && !prev;
-        if (fresh) {
-          const ctrl = controllers[idx];
-          if (ctrl) {
-            const tempMat = new THREE.Matrix4().extractRotation(ctrl.matrixWorld);
-            const rc = new THREE.Raycaster();
-            rc.ray.origin.setFromMatrixPosition(ctrl.matrixWorld);
-            rc.ray.direction.set(0, 0, -1).applyMatrix4(tempMat);
-            this._tryActivateFromRay(rc);
-          }
-        }
-        this._prevSelect.set(source.handedness, pressed);
-        idx++;
-      }
-    }
-
-    // Desktop click
-    if (this._desktopClick) {
-      const rc = new THREE.Raycaster();
-      rc.setFromCamera(this._desktopClick, this.ctx.camera);
-      this._tryActivateFromRay(rc);
-      this._desktopClick = null;
-    }
-  }
-
-  _tryActivateFromRay(rc) {
-    // Sprite.raycast dereferences raycaster.camera for billboard projection.
-    // The VR branch builds rc by hand and never sets it, so do it here.
-    if (!rc.camera) rc.camera = this.ctx.camera;
-    for (const ped of this.pedestals) {
-      const hits = rc.intersectObject(ped.group, true);
-      if (hits.length > 0) {
-        this._activate(ped);
-        return;
-      }
-    }
-  }
-
-  _activate(ped) {
-    const isFirstActivation = !this.activated.has(ped.idx);
-    if (isFirstActivation) {
-      this.activated.add(ped.idx);
-      this._revealBar(ped.idx);
-      ped.coreMat.emissiveIntensity = 0.7;
-
-      postTelemetry([
-        {
-          session_id: window.__VDV_SESSION_ID || 'anon',
-          event_type: 'l2_activate',
-          level: 'L2',
-          ligand: ped.ligand.name,
-          activation_index: this.activated.size,
-          ts: Date.now(),
-        },
-      ]);
-    }
-    this._paintNarrative(ped.ligand);
-  }
-
-  // ---- helpers ------------------------------------------------------------
-
-  _createLabelSprite(text, color) {
-    const tex = this._textTexture(text, '#ffffff', 28, color);
-    const mat = new THREE.SpriteMaterial({ map: tex, transparent: true, depthTest: false });
-    const sprite = new THREE.Sprite(mat);
-    sprite.scale.set(0.4, 0.1, 1);
-    return sprite;
-  }
-
-  _createTextSprite(text, color, size) {
-    const tex = this._textTexture(text, color, size);
-    const mat = new THREE.MeshBasicMaterial({ map: tex, transparent: true, depthTest: false, side: THREE.DoubleSide });
-    return new THREE.Mesh(new THREE.PlaneGeometry(1, 1), mat);
-  }
-
-  _textTexture(text, color, size, accentColor) {
-    const canvas = document.createElement('canvas');
-    canvas.width = 512;
-    canvas.height = 64;
-    const ctx = canvas.getContext('2d');
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-    if (accentColor) {
-      ctx.fillStyle = `rgba(${(accentColor >> 16) & 0xff}, ${(accentColor >> 8) & 0xff}, ${accentColor & 0xff}, 0.15)`;
-      ctx.fillRect(0, 0, canvas.width, canvas.height);
-    }
-    ctx.fillStyle = color;
-    ctx.font = `bold ${size}px ui-sans-serif, system-ui, sans-serif`;
+    ctx.clearRect(0, 0, 512, 96);
+    ctx.fillStyle = 'rgba(8, 12, 28, 0.85)';
+    ctx.beginPath();
+    ctx.roundRect(0, 0, 512, 96, 12);
+    ctx.fill();
+    const colourStr = '#' + colorHex.toString(16).padStart(6, '0');
+    ctx.fillStyle = colourStr;
+    ctx.font = 'bold 56px ui-sans-serif, system-ui, sans-serif';
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
-    ctx.fillText(text, canvas.width / 2, canvas.height / 2);
+    ctx.fillText(text, 256, 48);
     const tex = new THREE.CanvasTexture(canvas);
     tex.colorSpace = THREE.SRGBColorSpace;
     tex.minFilter = THREE.LinearFilter;
     return tex;
   }
 
-  _wrapText(ctx, text, maxWidth) {
-    const words = text.split(/\s+/);
-    const lines = [];
-    let line = '';
-    for (const word of words) {
-      const test = line ? `${line} ${word}` : word;
-      if (ctx.measureText(test).width > maxWidth && line) {
-        lines.push(line);
-        line = word;
-      } else {
-        line = test;
+  _buildBarChart(ligands) {
+    const group = new THREE.Group();
+    group.position.set(0, 1.85, -2.3);
+
+    const W = 1.6, H = 0.8;
+    const panel = new THREE.Mesh(
+      new THREE.PlaneGeometry(W, H),
+      new THREE.MeshBasicMaterial({
+        color: 0x080c1c, transparent: true, opacity: 0.85, side: THREE.DoubleSide,
+      })
+    );
+    group.add(panel);
+
+    // Title
+    const titleTex = this._makeTextTexture(
+      'COX-2 Vina ΔG (kcal/mol) — lower is tighter',
+      '#9ad9ff', 30
+    );
+    const title = new THREE.Mesh(
+      new THREE.PlaneGeometry(W * 0.95, 0.07),
+      new THREE.MeshBasicMaterial({ map: titleTex, transparent: true })
+    );
+    title.position.set(0, H / 2 - 0.07, 0.005);
+    group.add(title);
+
+    // Sort ligands by rank for visual ordering — left = strongest binder
+    const sorted = [...ligands].sort((a, b) => a.rank - b.rank);
+    const minScore = Math.min(...ligands.map((l) => l.vina_kcal));
+    const maxBarHeight = H * 0.65;
+    const innerWidth = W * 0.9;
+    const innerStart = -innerWidth / 2;
+    const slot = innerWidth / sorted.length;
+
+    const bars = [];
+    for (let i = 0; i < sorted.length; i++) {
+      const lig = sorted[i];
+      const colorHex = parseInt(lig.color.replace('0x', ''), 16);
+      const fullHeight = maxBarHeight * Math.abs(lig.vina_kcal / minScore);
+      const x = innerStart + slot * (i + 0.5);
+      const baseY = -H / 2 + 0.18;
+
+      const bar = new THREE.Mesh(
+        new THREE.PlaneGeometry(slot * 0.55, 1),
+        new THREE.MeshBasicMaterial({ color: colorHex, transparent: true, opacity: 0 })
+      );
+      bar.position.set(x, baseY, 0.003);
+      bar.scale.y = 0.0001;
+      group.add(bar);
+
+      const labelTex = this._makeTextTexture(lig.name, '#ffffff', 22);
+      const label = new THREE.Mesh(
+        new THREE.PlaneGeometry(slot * 0.95, 0.05),
+        new THREE.MeshBasicMaterial({ map: labelTex, transparent: true })
+      );
+      label.position.set(x, baseY - 0.06, 0.005);
+      group.add(label);
+
+      const valueCanvas = document.createElement('canvas');
+      valueCanvas.width = 256; valueCanvas.height = 64;
+      const valueTex = new THREE.CanvasTexture(valueCanvas);
+      valueTex.colorSpace = THREE.SRGBColorSpace;
+      const valueLabel = new THREE.Mesh(
+        new THREE.PlaneGeometry(slot * 0.85, 0.05),
+        new THREE.MeshBasicMaterial({ map: valueTex, transparent: true })
+      );
+      valueLabel.visible = false;
+      valueLabel.position.z = 0.005;
+      group.add(valueLabel);
+
+      bars.push({ bar, fullHeight, baseY, valueLabel, valueCanvas, valueTex, lig });
+    }
+
+    this._add(group);
+    this.barChart = { group, bars };
+  }
+
+  _makeTextTexture(text, color, fontPx) {
+    const canvas = document.createElement('canvas');
+    canvas.width = 1024; canvas.height = 96;
+    const ctx = canvas.getContext('2d');
+    ctx.clearRect(0, 0, 1024, 96);
+    ctx.fillStyle = color;
+    ctx.font = `${fontPx}px ui-sans-serif, system-ui, sans-serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(text, 512, 48);
+    const tex = new THREE.CanvasTexture(canvas);
+    tex.colorSpace = THREE.SRGBColorSpace;
+    tex.minFilter = THREE.LinearFilter;
+    return tex;
+  }
+
+  _fillBar(ligandName, vinaKcal) {
+    const entry = this.barChart.bars.find((b) => b.lig.name === ligandName);
+    if (!entry) return;
+    const { bar, fullHeight, baseY, valueLabel, valueCanvas, valueTex } = entry;
+    const startTime = performance.now();
+    const duration = 600;
+    const tick = () => {
+      const t = Math.min(1, (performance.now() - startTime) / duration);
+      const eased = 1 - (1 - t) * (1 - t);
+      bar.scale.y = Math.max(0.0001, fullHeight * eased);
+      bar.position.y = baseY + (fullHeight * eased) / 2;
+      bar.material.opacity = 0.85 * eased;
+      if (t < 1) requestAnimationFrame(tick);
+      else {
+        const ctx = valueCanvas.getContext('2d');
+        ctx.clearRect(0, 0, 256, 64);
+        ctx.fillStyle = '#ffffff';
+        ctx.font = 'bold 40px ui-sans-serif, system-ui, sans-serif';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(`${vinaKcal.toFixed(1)}`, 128, 32);
+        valueTex.needsUpdate = true;
+        valueLabel.position.y = baseY + fullHeight + 0.03;
+        valueLabel.visible = true;
+      }
+    };
+    tick();
+  }
+
+  _buildHud(data) {
+    this.hud = new THREE.Group();
+    this.hud.position.set(-0.45, 0.05, -1.2);
+    this.ctx.camera.add(this.hud);
+
+    // Progress card
+    const canvas = document.createElement('canvas');
+    canvas.width = 768; canvas.height = 256;
+    this._hudCanvas = canvas;
+    this._hudCtx = canvas.getContext('2d');
+    const tex = new THREE.CanvasTexture(canvas);
+    tex.colorSpace = THREE.SRGBColorSpace;
+    tex.minFilter = THREE.LinearFilter;
+    this._hudTex = tex;
+    const mesh = new THREE.Mesh(
+      new THREE.PlaneGeometry(0.6, 0.20),
+      new THREE.MeshBasicMaterial({
+        map: tex, transparent: true, depthTest: false, depthWrite: false,
+      })
+    );
+    mesh.position.set(0, 0.22, 0);
+    mesh.scale.setScalar(0.7);
+    mesh.renderOrder = 998;
+    this.hud.add(mesh);
+    this._hudMesh = mesh;
+    this._renderHud(null);
+
+    // Brief panel from narrative-panel module
+    this.narrativePanel = buildNarrativePanel({
+      pocketCenter: { x: 0, y: 0, z: 0 },
+      pocketAnnotation: { ...this.pocket, key_residues: [] },
+      narrative: { brief: data.brief, score_hint: data.score_hint, residue_notes: {} },
+      scoreReadoutAnchor: null,
+    });
+    if (this.narrativePanel.brief) {
+      this.narrativePanel.group.remove(this.narrativePanel.brief);
+      const b = this.narrativePanel.brief;
+      b.position.set(0, -0.20, 0);
+      b.scale.setScalar(0.42);
+      b.material.depthTest = false;
+      b.material.depthWrite = false;
+      b.renderOrder = 998;
+      this.hud.add(b);
+    }
+    this.narrativePanel.group.position.copy(this._uiWorldAnchor);
+    this.ctx.scene.add(this.narrativePanel.group);
+    this.objects.push(this.narrativePanel.group);
+  }
+
+  _renderHud(holdingLigand) {
+    const ctx = this._hudCtx;
+    ctx.clearRect(0, 0, 768, 256);
+    ctx.fillStyle = 'rgba(8, 12, 28, 0.92)';
+    ctx.beginPath();
+    ctx.roundRect(0, 0, 768, 256, 24);
+    ctx.fill();
+
+    ctx.fillStyle = '#9ad9ff';
+    ctx.font = 'bold 44px ui-sans-serif, system-ui, sans-serif';
+    ctx.textBaseline = 'top';
+    ctx.fillText('Rank the NSAIDs', 24, 18);
+
+    ctx.fillStyle = '#ffd166';
+    ctx.font = 'bold 36px ui-sans-serif, system-ui, sans-serif';
+    ctx.fillText(`Docked ${this.activated.size} / ${this.pedestals.length}`, 24, 78);
+
+    if (holdingLigand) {
+      ctx.fillStyle = '#06d6a0';
+      ctx.font = 'bold 30px ui-sans-serif, system-ui, sans-serif';
+      ctx.fillText(`Holding: ${holdingLigand.name}`, 24, 138);
+      ctx.fillStyle = '#aaaacc';
+      ctx.font = '24px ui-sans-serif, system-ui, sans-serif';
+      ctx.fillText('Drop into the green pocket sphere', 24, 178);
+    } else {
+      ctx.fillStyle = '#aaaacc';
+      ctx.font = '26px ui-sans-serif, system-ui, sans-serif';
+      ctx.fillText('Trigger-grab a ligand from the pedestals', 24, 138);
+      ctx.fillText('Drop it into the green COX-2 pocket', 24, 178);
+    }
+
+    this._hudTex.needsUpdate = true;
+  }
+
+  _buildSuccessCard() {
+    const canvas = document.createElement('canvas');
+    canvas.width = 1024; canvas.height = 512;
+    const ctx = canvas.getContext('2d');
+    ctx.fillStyle = 'rgba(6, 214, 160, 0.95)';
+    ctx.beginPath();
+    ctx.roundRect(0, 0, 1024, 512, 36);
+    ctx.fill();
+    ctx.fillStyle = '#0a2e22';
+    ctx.font = 'bold 96px ui-sans-serif, system-ui, sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText('ALL FIVE DOCKED!', 512, 180);
+    ctx.font = 'bold 48px ui-sans-serif, system-ui, sans-serif';
+    ctx.fillText('NSAID ranking complete', 512, 280);
+    ctx.font = '36px ui-sans-serif, system-ui, sans-serif';
+    const lines = (this.data.complete_message || '').split(/(?<=[.;])\s+/).slice(0, 2);
+    let yy = 360;
+    for (const line of lines) { ctx.fillText(line, 512, yy); yy += 44; }
+
+    const tex = new THREE.CanvasTexture(canvas);
+    tex.colorSpace = THREE.SRGBColorSpace;
+    const mesh = new THREE.Mesh(
+      new THREE.PlaneGeometry(0.95, 0.48),
+      new THREE.MeshBasicMaterial({
+        map: tex, transparent: true, opacity: 0, depthTest: false,
+      })
+    );
+    mesh.position.set(0, 0, -1.4);
+    mesh.visible = false;
+    mesh.renderOrder = 999;
+    this.ctx.camera.add(mesh);
+    this.successCard = mesh;
+  }
+
+  _showSuccessCard() {
+    if (!this.successCard) return;
+    this.successCard.visible = true;
+    const startTime = performance.now();
+    const fadeIn = 280, hold = 2400, fadeOut = 540;
+    const total = fadeIn + hold + fadeOut;
+    const animate = () => {
+      const e = performance.now() - startTime;
+      let opacity;
+      if (e < fadeIn) opacity = e / fadeIn;
+      else if (e < fadeIn + hold) opacity = 1;
+      else if (e < total) opacity = 1 - (e - fadeIn - hold) / fadeOut;
+      else { this.successCard.visible = false; return; }
+      this.successCard.material.opacity = opacity;
+      requestAnimationFrame(animate);
+    };
+    animate();
+
+    const session = this.ctx.renderer.xr.getSession();
+    if (session) {
+      for (const src of session.inputSources) {
+        src.gamepad?.hapticActuators?.[0]?.pulse(0.8, 90);
       }
     }
-    if (line) lines.push(line);
-    return lines;
+  }
+
+  // ------------------------------------------------------------------
+  // Update loop
+  // ------------------------------------------------------------------
+
+  update(dt, controllers) {
+    if (!this.ready) return;
+
+    this.telemetryAccumMs += dt;
+
+    const grabbed = this._findGrabbedLigand(controllers);
+    this._renderHud(grabbed?.userData?.ligandData ?? null);
+
+    if (grabbed) this._checkDock(grabbed);
+
+    this._handleGripGestures(controllers);
+    this._handleLeftA(controllers);
+  }
+
+  _findGrabbedLigand(controllers) {
+    for (const c of controllers) {
+      const held = c?.userData?.held;
+      if (held?.userData?.ligandId) return held;
+    }
+    return null;
+  }
+
+  _checkDock(ligandMesh) {
+    const ligandId = ligandMesh.userData.ligandId;
+    if (this.activated.has(ligandId)) return;
+
+    const worldPos = new THREE.Vector3();
+    ligandMesh.getWorldPosition(worldPos);
+    // Distance to pocket-centre in pivot-LOCAL Å (geometry was offset around
+    // the pocket so origin = pocket centre).
+    const pivotInv = this.pivot.matrixWorld.clone().invert();
+    const localPos = worldPos.clone().applyMatrix4(pivotInv);
+    const dist = localPos.length();
+
+    if (dist < DOCK_TOLERANCE) this._dockLigand(ligandMesh);
+  }
+
+  _dockLigand(ligandMesh) {
+    const lig = ligandMesh.userData.ligandData;
+    this.activated.add(lig.name);
+
+    // Detach from controller (or wherever) and put back on the pedestal as
+    // a non-grabbable "completed" marker.
+    const spawnPos = ligandMesh.userData.spawnPos.clone();
+    const spawnQuat = ligandMesh.userData.spawnQuat.clone();
+    const spawnScale = ligandMesh.userData.spawnScale.clone();
+    const spawnParent = ligandMesh.userData.spawnParent;
+
+    if (ligandMesh.parent) ligandMesh.parent.remove(ligandMesh);
+    spawnParent.add(ligandMesh);
+    ligandMesh.position.copy(spawnPos);
+    ligandMesh.quaternion.copy(spawnQuat);
+    ligandMesh.scale.copy(spawnScale);
+    ligandMesh.userData.grabbable = false;
+
+    // Visual lock: green-emissive ligand + pedestal ring goes green
+    ligandMesh.traverse((c) => {
+      if (c.material?.emissive) {
+        c.material.emissive.setHex(0x06d6a0);
+        c.material.emissiveIntensity = 0.6;
+      }
+    });
+    const ped = this.pedestals.find((p) => p.ligand.name === lig.name);
+    if (ped?.ringMat) ped.ringMat.color.setHex(0x06d6a0);
+
+    // Fill bar chart with ground-truth Vina ΔG
+    this._fillBar(lig.name, lig.vina_kcal);
+
+    // Haptic burst
+    const session = this.ctx.renderer.xr.getSession();
+    if (session) {
+      for (const src of session.inputSources) {
+        src.gamepad?.hapticActuators?.[0]?.pulse(0.5, 60);
+      }
+    }
+
+    postTelemetry([{
+      session_id: window.__VDV_SESSION_ID || 'anon',
+      event_type: 'l2_dock',
+      ligand: lig.name,
+      vina_kcal: lig.vina_kcal,
+      activation_index: this.activated.size,
+      ts: Date.now(),
+    }]);
+
+    if (this.activated.size === this.pedestals.length && !this.completed) {
+      this._showComplete();
+    }
+  }
+
+  _showComplete() {
+    this.completed = true;
+    this._showSuccessCard();
+    postTelemetry([{
+      session_id: window.__VDV_SESSION_ID || 'anon',
+      event_type: 'level_complete',
+      level: 'L2',
+      ts: Date.now(),
+    }]);
+    this._completeTimer = setTimeout(() => {
+      if (this.onComplete) this.onComplete();
+    }, 3500);
+  }
+
+  _handleLeftA(controllers) {
+    const session = this.ctx.renderer.xr.getSession();
+    if (!session) return;
+    for (const src of session.inputSources) {
+      if (src.handedness !== 'left' || !src.gamepad) continue;
+      const aPressed = !!src.gamepad.buttons?.[4]?.pressed;
+      if (aPressed && !this.lastButtons.A && this.narrativePanel?.toggleBrief) {
+        this.narrativePanel.toggleBrief();
+      }
+      this.lastButtons.A = aPressed;
+    }
+  }
+
+  _handleGripGestures(controllers) {
+    const session = this.ctx.renderer.xr.getSession();
+    if (!session) return;
+
+    let leftDown = false, rightDown = false;
+    let leftCtrl = null, rightCtrl = null;
+    let idx = 0;
+    for (const src of session.inputSources) {
+      if (!src.gamepad || !src.handedness) { idx++; continue; }
+      const gripPressed = !!src.gamepad.buttons?.[1]?.pressed;
+      const ctrl = controllers[idx];
+      if (!ctrl) { idx++; continue; }
+      if (src.handedness === 'left')  { leftDown  = gripPressed; leftCtrl  = ctrl; }
+      else if (src.handedness === 'right') { rightDown = gripPressed; rightCtrl = ctrl; }
+      idx++;
+    }
+
+    const numActive = (leftDown ? 1 : 0) + (rightDown ? 1 : 0);
+    const s = this._gripState;
+
+    if (numActive === 0) { s.active = 0; return; }
+
+    if (numActive === 1) {
+      const ctrl = leftDown ? leftCtrl : rightCtrl;
+      if (!ctrl) return;
+      const ctrlPos = new THREE.Vector3();
+      const ctrlQuat = new THREE.Quaternion();
+      ctrl.getWorldPosition(ctrlPos);
+      ctrl.getWorldQuaternion(ctrlQuat);
+
+      if (s.active !== 1) {
+        s.active = 1;
+        s.ctrlStartPos = ctrlPos.clone();
+        s.ctrlStartQuat = ctrlQuat.clone();
+        s.pivotStartPos = this.pivot.position.clone();
+        s.pivotStartQuat = this.pivot.quaternion.clone();
+      } else {
+        const deltaPos = ctrlPos.clone().sub(s.ctrlStartPos);
+        this.pivot.position.copy(s.pivotStartPos).add(deltaPos);
+        const deltaQuat = ctrlQuat.clone().multiply(s.ctrlStartQuat.clone().invert());
+        const amp = _amplifyQuat(deltaQuat, ROTATION_GAIN);
+        this.pivot.quaternion.copy(s.pivotStartQuat).premultiply(amp);
+        this._syncUiAnchor();
+      }
+    } else {
+      const leftPos = new THREE.Vector3(); leftCtrl.getWorldPosition(leftPos);
+      const rightPos = new THREE.Vector3(); rightCtrl.getWorldPosition(rightPos);
+      const currentDist = leftPos.distanceTo(rightPos);
+      const currentMid = leftPos.clone().add(rightPos).multiplyScalar(0.5);
+
+      if (s.active !== 2) {
+        s.active = 2;
+        s.bimanualDistStart = currentDist;
+        s.bimanualMidStart = currentMid.clone();
+        s.pivotScaleStart = this.pivot.scale.x;
+        s.pivotPosStart = this.pivot.position.clone();
+      } else {
+        const ratio = currentDist / Math.max(0.05, s.bimanualDistStart);
+        const newScale = Math.max(
+          PIVOT_SCALE_MIN,
+          Math.min(PIVOT_SCALE_MAX, s.pivotScaleStart * ratio)
+        );
+        this.pivot.scale.setScalar(newScale);
+        const midDelta = currentMid.clone().sub(s.bimanualMidStart);
+        this.pivot.position.copy(s.pivotPosStart).add(midDelta);
+        this._syncUiAnchor();
+      }
+    }
+  }
+
+  _syncUiAnchor() {
+    if (!this.pivot) return;
+    this._uiWorldAnchor.copy(this.pivot.position);
+    if (this.narrativePanel) this.narrativePanel.group.position.copy(this._uiWorldAnchor);
+  }
+
+  // ------------------------------------------------------------------
+  // Lifecycle
+  // ------------------------------------------------------------------
+
+  getGrabbables() {
+    return this.pedestals.map((p) => p.mesh);
   }
 
   _add(obj) {
@@ -581,20 +769,38 @@ export default class LevelTwoScene {
     this.objects.push(obj);
   }
 
-  // ---- lifecycle ----------------------------------------------------------
-
-  getGrabbables() {
-    // L2 has no draggable objects — selection is point-and-click on pedestals.
-    return [];
-  }
-
   destroy() {
+    if (this._completeTimer) { clearTimeout(this._completeTimer); this._completeTimer = null; }
+
+    // Detach any held ligand from controller back to its pedestal so it
+    // doesn't survive into the next scene.
+    for (const ped of this.pedestals) {
+      if (ped.mesh && ped.mesh.parent && ped.mesh.parent !== ped.group) {
+        ped.mesh.parent.remove(ped.mesh);
+      }
+    }
+
+    if (this.hud?.parent) {
+      this.hud.parent.remove(this.hud);
+      this.hud.traverse?.((c) => {
+        if (c.geometry) c.geometry.dispose();
+        if (c.material) {
+          if (Array.isArray(c.material)) c.material.forEach((m) => m.dispose());
+          else c.material.dispose();
+        }
+      });
+    }
+    if (this.successCard?.parent) {
+      this.successCard.parent.remove(this.successCard);
+      if (this.successCard.geometry) this.successCard.geometry.dispose();
+      if (this.successCard.material) this.successCard.material.dispose();
+    }
+
     for (const obj of this.objects) {
       this.ctx.scene.remove(obj);
       obj.traverse?.((c) => {
         if (c.geometry) c.geometry.dispose();
         if (c.material) {
-          if (c.material.map) c.material.map.dispose();
           if (Array.isArray(c.material)) c.material.forEach((m) => m.dispose());
           else c.material.dispose();
         }

--- a/src/scenes/LevelTwoScene.js
+++ b/src/scenes/LevelTwoScene.js
@@ -107,6 +107,24 @@ function _recolor(root, hex, opts = {}) {
   });
 }
 
+// Same EdgesGeometry overlay as L1 — dark silhouette lines on top of the
+// translucent surface read as ball+stick.
+function _addStickOverlay(root, lineColorHex = 0x111122, angleThresholdDeg = 20) {
+  root.traverse((c) => {
+    if (!c.geometry || !(c.isMesh)) return;
+    const edges = new THREE.EdgesGeometry(c.geometry, angleThresholdDeg);
+    const mat = new THREE.LineBasicMaterial({
+      color: lineColorHex,
+      transparent: true,
+      opacity: 0.55,
+      depthWrite: false,
+    });
+    const lines = new THREE.LineSegments(edges, mat);
+    lines.userData.stickOverlay = true;
+    c.add(lines);
+  });
+}
+
 export default class LevelTwoScene {
   constructor(ctx) {
     this.ctx = ctx;
@@ -251,9 +269,11 @@ export default class LevelTwoScene {
       ring.position.y = PED_HEIGHT + 0.01;
       group.add(ring);
 
-      // Ligand GLB sitting on the pedestal — the grabbable
+      // Ligand GLB sitting on the pedestal — the grabbable.
+      // Translucent surface + dark edge overlay → ball+stick reading.
       mesh.scale.setScalar(LIGAND_HANDHELD_SCALE);
-      _recolor(mesh, colorHex, { emissiveIntensity: 0.40 });
+      _recolor(mesh, colorHex, { emissiveIntensity: 0.40, transparent: true, opacity: 0.55 });
+      _addStickOverlay(mesh);
       mesh.position.y = PED_HEIGHT + 0.10;
       mesh.userData.grabbable = true;
       mesh.userData.ligandId = lig.name;

--- a/src/scenes/TutorialScene.js
+++ b/src/scenes/TutorialScene.js
@@ -442,19 +442,22 @@ export default class TutorialScene {
         break;
 
       case STATES.WAIT_GRAB:
+        // Either grab (trigger) or just push the molecule with the thumbstick.
+        // Either path advances to WAIT_SNAP; we also auto-advance after 5 s so
+        // a thumbstick-only user is never stuck waiting for a grab.
         if (isHeld) this._enterState(STATES.GRABBED);
+        else if (this.stateTime > 5000) this._enterState(STATES.WAIT_SNAP);
         this._checkTimeout(STATES.WAIT_GRAB);
         break;
 
       case STATES.GRABBED:
-        // Auto-advance handled by timer
+        // Auto-advance handled by timer (set in _enterState)
         break;
 
       case STATES.WAIT_SNAP:
-        if (!isHeld) {
-          this._enterState(STATES.WAIT_GRAB);
-          return;
-        }
+        // No isHeld kick-back — the user may push the ligand onto the ghost
+        // either by hand-grab or thumbstick. Snap fires on positional overlap
+        // alone so a release-mid-drag (or pure-thumbstick) flow still works.
         if (distToGhost < TARGET_OVERLAP_DIST) {
           this._enterState(STATES.SNAPPED);
         }

--- a/src/scenes/TutorialScene.js
+++ b/src/scenes/TutorialScene.js
@@ -555,6 +555,36 @@ export default class TutorialScene {
     });
   }
 
+  // Thumbstick → object translation (player is locked in space).
+  // Forwarded from main.js's handleThumbstickInput. Both thumbsticks
+  // contribute different axes:
+  //   left  X  → world X   (right/left)
+  //   left  Y  → world Z   (forward/back; push forward = away from camera)
+  //   right Y  → world Y   (up/down)
+  //
+  // Skipped once the ligand is locked (post-snap) so the user can't yank
+  // it back out of the dock with the stick.
+  applyThumbstickInput({ leftX, leftY, rightY }, dt) {
+    if (!this.ligandGroup) return;
+    if (!this.ligandGroup.userData.grabbable) return;
+
+    const speed = 0.6; // m/s at full deflection
+    const k = (dt / 1000) * speed;
+
+    // World-space translation; ligand may be parented to a controller while
+    // grabbed, so go through getWorldPosition + parent.worldToLocal so the
+    // axes always feel global.
+    const worldPos = new THREE.Vector3();
+    this.ligandGroup.getWorldPosition(worldPos);
+    worldPos.x += leftX * k;
+    worldPos.z += leftY * k;       // push forward (Y=-1) → -z, toward the pocket
+    worldPos.y -= rightY * k;      // push up (Y=-1) → +y
+    if (this.ligandGroup.parent) {
+      this.ligandGroup.parent.worldToLocal(worldPos);
+    }
+    this.ligandGroup.position.copy(worldPos);
+  }
+
   _ligandToPocketDist() {
     return this.ligandGroup.position.distanceTo(this.pocketCenter);
   }

--- a/src/scenes/TutorialScene.js
+++ b/src/scenes/TutorialScene.js
@@ -21,15 +21,19 @@ const POCKET_RADIUS   = 0.25;
 const MARKER_RADIUS   = 0.035;
 const LIGAND_ARM_R    = 0.03;
 const LIGAND_BOND_R   = 0.012;
-const SNAP_DIST       = 0.10;
-const ALIGN_THRESHOLD = 0.65;
-const HBOND_SHOW_DIST = 0.18;
+// Ghost-overlay UX:
+// A semi-transparent target ghost of the ligand sits at the docked pose.
+// User just has to overlay their held ligand onto the ghost — when world-
+// space distance between centres is below TARGET_OVERLAP_DIST, snap fires.
+// Rotation is corrected by the snap animation, so the user doesn't have
+// to nail orientation manually.
+const TARGET_OVERLAP_DIST = 0.12;   // 12 cm tolerance volume around target
+const HBOND_SHOW_DIST = 0.22;
 const CLASH_DIST      = 0.06;
 
 // Per-state timeouts (ms) before a progressive hint fires
 const TIMEOUTS = {
   [STATES.WAIT_GRAB]:   12000,
-  [STATES.WAIT_ROTATE]: 18000,
   [STATES.WAIT_SNAP]:   18000,
 };
 
@@ -56,6 +60,7 @@ export default class TutorialScene {
   init() {
     this._buildPocket();
     this._buildLigand();
+    this._buildGhostLigand();
     this._buildForceField();
     this._buildPrompt();
     this._buildArrow();
@@ -201,6 +206,55 @@ export default class TutorialScene {
     this.grabbables.push(group);
   }
 
+  // ---- ghost ligand (visual target) ---------------------------------------
+
+  // The ghost is a low-opacity duplicate of the ligand, sat at the docked
+  // pose. The user's job is simply to overlay their held copy onto this.
+  // Geometry-wise the arms of the original ligand at identity rotation
+  // already coincide with the H-bond markers (both _buildLigand and
+  // _buildPocket use the same yOff / rAtY / angles), so the ghost goes at
+  // pocketCenter with identity orientation.
+  _buildGhostLigand() {
+    const ghost = this.ligandGroup.clone(true);
+    ghost.traverse((c) => {
+      if (!c.material) return;
+      c.material = c.material.clone();
+      c.material.transparent = true;
+      c.material.opacity = 0.28;
+      c.material.depthWrite = false;
+      if (c.material.emissive) {
+        c.material.emissive.setHex(0x06d6a0);
+        c.material.emissiveIntensity = 0.5;
+      }
+    });
+    ghost.userData.grabbable = false;
+    ghost.userData.tutorialLigand = false;
+    ghost.position.copy(this.pocketCenter);
+    ghost.quaternion.identity();
+    this.ghostLigand = ghost;
+    this.ghostTargetPos = this.pocketCenter.clone();
+    this.ghostTargetQuat = ghost.quaternion.clone();
+    this._add(ghost);
+  }
+
+  _hideGhost() {
+    if (!this.ghostLigand) return;
+    // Fade out over 350 ms, then hide.
+    const start = performance.now();
+    const ghost = this.ghostLigand;
+    const fade = () => {
+      const t = Math.min(1, (performance.now() - start) / 350);
+      ghost.traverse((c) => {
+        if (c.material && c.material.opacity !== undefined) {
+          c.material.opacity = 0.28 * (1 - t);
+        }
+      });
+      if (t < 1) requestAnimationFrame(fade);
+      else ghost.visible = false;
+    };
+    fade();
+  }
+
   // ---- force field overlay ------------------------------------------------
 
   _buildForceField() {
@@ -342,22 +396,14 @@ export default class TutorialScene {
         break;
 
       case STATES.GRABBED:
-        this._setPrompt('Great! Now rotate it to align the arms with the markers');
+        this._setPrompt('Move it onto the green ghost in the pocket');
         this._hideArrow();
-        // Auto-advance after 1.2s
-        this._autoAdvance(STATES.WAIT_ROTATE, 1200);
-        break;
-
-      case STATES.WAIT_ROTATE:
-        this._setPrompt('Rotate it so the arms match the pocket markers');
-        break;
-
-      case STATES.ROTATING:
-        this._setPrompt('Looking good! Keep aligning...');
+        // Auto-advance after a short beat so the user reads the prompt.
+        this._autoAdvance(STATES.WAIT_SNAP, 600);
         break;
 
       case STATES.WAIT_SNAP:
-        this._setPrompt('Move it into the pocket');
+        this._setPrompt('Overlay the molecule onto the green ghost');
         this._showArrow(this.pocketCenter);
         break;
 
@@ -386,12 +432,12 @@ export default class TutorialScene {
 
   _updateState(controllers, dt) {
     const isHeld = this._isLigandHeld(controllers);
-    const dist = this._ligandToPocketDist();
-    const alignment = this._alignmentScore();
+    // Distance check is now world-space distance between the held ligand
+    // and the ghost target — purely positional, no alignment math needed.
+    const distToGhost = this._ligandWorldDistTo(this.ghostTargetPos);
 
     switch (this.state) {
       case STATES.INTRO:
-        // Advance on trigger or after 3s
         if (this.stateTime > 3000) this._enterState(STATES.WAIT_GRAB);
         break;
 
@@ -404,41 +450,23 @@ export default class TutorialScene {
         // Auto-advance handled by timer
         break;
 
-      case STATES.WAIT_ROTATE:
-        if (!isHeld) {
-          // Dropped — go back to WAIT_GRAB gently
-          this._enterState(STATES.WAIT_GRAB);
-          return;
-        }
-        if (alignment > ALIGN_THRESHOLD * 0.5) this._enterState(STATES.ROTATING);
-        this._checkTimeout(STATES.WAIT_ROTATE);
-        break;
-
-      case STATES.ROTATING:
-        if (!isHeld) {
-          this._enterState(STATES.WAIT_GRAB);
-          return;
-        }
-        if (alignment > ALIGN_THRESHOLD) {
-          this._enterState(STATES.WAIT_SNAP);
-        } else if (alignment < ALIGN_THRESHOLD * 0.3) {
-          this._enterState(STATES.WAIT_ROTATE);
-        }
-        break;
-
       case STATES.WAIT_SNAP:
         if (!isHeld) {
           this._enterState(STATES.WAIT_GRAB);
           return;
         }
-        if (dist < SNAP_DIST && alignment > ALIGN_THRESHOLD) {
+        if (distToGhost < TARGET_OVERLAP_DIST) {
           this._enterState(STATES.SNAPPED);
         }
-        // If far away and poor alignment, nudge back
-        if (dist < SNAP_DIST && alignment < ALIGN_THRESHOLD * 0.5) {
-          this._setPrompt('Almost there! Rotate a bit more to align');
-        }
         this._checkTimeout(STATES.WAIT_SNAP);
+        break;
+
+      // WAIT_ROTATE and ROTATING are kept in STATES for backward-compat
+      // (skip-shortcut order array references them) but the user never
+      // enters them — overlay UX collapses to a single positioning step.
+      case STATES.WAIT_ROTATE:
+      case STATES.ROTATING:
+        this._enterState(STATES.WAIT_SNAP);
         break;
 
       case STATES.SNAPPED:
@@ -446,7 +474,6 @@ export default class TutorialScene {
         break;
     }
 
-    // Force-skip: both triggers held for 2s
     this._checkForceSkip(controllers, dt);
   }
 
@@ -482,24 +509,20 @@ export default class TutorialScene {
         }
         break;
 
-      case STATES.WAIT_ROTATE:
-        if (this.hintLevel >= 2) {
-          this._setPrompt('Twist your wrist to rotate the molecule');
-        }
-        if (this.hintLevel >= 3) {
-          // Auto-rotate the ligand slightly toward alignment
-          this._nudgeAlignment(0.02);
-        }
-        break;
-
       case STATES.WAIT_SNAP:
         if (this.hintLevel >= 2) {
           this._showArrow(this.pocketCenter);
-          this._setPrompt('Move the molecule toward the pocket');
+          this._setPrompt('Bring the molecule into the green ghost');
         }
         if (this.hintLevel >= 3) {
-          // Gently pull ligand toward pocket
-          this._nudgeTowardPocket(0.003);
+          // Make the ghost pulse so the target is unmissable.
+          if (this.ghostLigand) {
+            this.ghostLigand.traverse((c) => {
+              if (c.material && c.material.emissive) {
+                c.material.emissive.setHex(0xffd166);
+              }
+            });
+          }
         }
         break;
     }
@@ -534,6 +557,12 @@ export default class TutorialScene {
 
   _ligandToPocketDist() {
     return this.ligandGroup.position.distanceTo(this.pocketCenter);
+  }
+
+  _ligandWorldDistTo(worldTarget) {
+    const wp = new THREE.Vector3();
+    this.ligandGroup.getWorldPosition(wp);
+    return wp.distanceTo(worldTarget);
   }
 
   _alignmentScore() {
@@ -701,36 +730,108 @@ export default class TutorialScene {
   // ---- snap animation -----------------------------------------------------
 
   _startSnapAnimation() {
-    // Detach from controller if held, attach to scene
+    // Detach from controller and attach to scene so the target pose is
+    // fixed in world space.
     if (this.ligandGroup.parent !== this.ctx.scene) {
       this.ctx.scene.attach(this.ligandGroup);
     }
     this.snapAnim = {
       startPos: this.ligandGroup.position.clone(),
       startQuat: this.ligandGroup.quaternion.clone(),
-      targetPos: this.pocketCenter.clone(),
-      targetQuat: this._computeAlignmentQuaternion() || this.ligandGroup.quaternion.clone(),
+      targetPos: this.ghostTargetPos.clone(),
+      targetQuat: this.ghostTargetQuat.clone(),
       elapsed: 0,
       duration: 350,
     };
-    // Make ligand non-grabbable during snap
+    // Lock: not grabbable, not in active grab list. After snap the ligand
+    // stays put — no more wandering.
     this.ligandGroup.userData.grabbable = false;
+    const gi = this.grabbables.indexOf(this.ligandGroup);
+    if (gi !== -1) this.grabbables.splice(gi, 1);
+
+    // Positive feedback: fade the ghost out, haptic on both controllers,
+    // emissive flash on the now-locked ligand.
+    this._hideGhost();
+    this._snapHaptic();
+    this._snapVisualFlash();
+  }
+
+  _snapHaptic() {
+    const session = this.ctx.renderer.xr.getSession();
+    if (!session) return;
+    for (const src of session.inputSources) {
+      const a = src.gamepad?.hapticActuators?.[0];
+      a?.pulse(0.7, 80);
+    }
+  }
+
+  _snapVisualFlash() {
+    // Flash all ligand mesh emissives green for ~0.6s, then ease back to a
+    // higher resting intensity so the snapped ligand reads as "active".
+    this.ligandGroup.traverse((c) => {
+      if (c.material && c.material.emissive) {
+        c.userData._origEmissive = c.material.emissive.getHex();
+        c.userData._origEmissiveIntensity = c.material.emissiveIntensity ?? 0;
+        c.material.emissive.setHex(0x06d6a0);
+        c.material.emissiveIntensity = 1.4;
+      }
+    });
+    setTimeout(() => {
+      this.ligandGroup.traverse((c) => {
+        if (c.material && c.material.emissive && c.userData._origEmissive !== undefined) {
+          c.material.emissive.setHex(c.userData._origEmissive);
+          c.material.emissiveIntensity = Math.max(0.45, c.userData._origEmissiveIntensity);
+        }
+      });
+    }, 600);
+  }
+
+  _magneticAssist(dt, dist) {
+    // The ligand is parented to the holding controller while grabbed, so
+    // ligandGroup.position is in controller-local space. We must lerp in
+    // WORLD space and then convert back to local, otherwise the pull is
+    // inconsistent or invisible.
+    const target = this.pocketCenter;
+
+    // Falloff: stronger near the pocket center, gentler at the edge.
+    const t = Math.max(0, Math.min(1, 1 - dist / MAGNETIC_RADIUS));
+    const strength = MAGNETIC_PULL_BASE + (MAGNETIC_PULL_PEAK - MAGNETIC_PULL_BASE) * t;
+    const k = Math.min(1, (dt / 16) * strength);
+
+    // World-space lerp.
+    const worldPos = new THREE.Vector3();
+    this.ligandGroup.getWorldPosition(worldPos);
+    worldPos.lerp(target, k);
+    if (this.ligandGroup.parent) {
+      this.ligandGroup.parent.worldToLocal(worldPos);
+    }
+    this.ligandGroup.position.copy(worldPos);
+
+    // Rotation pull toward the best-alignment quaternion. _computeAlignmentQuaternion
+    // operates on world arm/marker directions so its output is a world-space
+    // delta rotation; applied to local quaternion this is an approximation
+    // (good enough when the holding controller has near-identity orientation
+    // relative to scene root).
+    const targetQuat = this._computeAlignmentQuaternion();
+    if (targetQuat) {
+      this.ligandGroup.quaternion.slerp(targetQuat, k);
+    }
   }
 
   _updateSnapAnim(dt) {
     const a = this.snapAnim;
     a.elapsed += dt;
     const t = Math.min(1, a.elapsed / a.duration);
-    // Ease out cubic
     const e = 1 - Math.pow(1 - t, 3);
     this.ligandGroup.position.lerpVectors(a.startPos, a.targetPos, e);
     this.ligandGroup.quaternion.slerpQuaternions(a.startQuat, a.targetQuat, e);
     if (t >= 1) {
       this.snapAnim = null;
-      // Snap feedback: pulse markers
+      // Marker pulse — slightly stronger than before so the docked state
+      // visibly settles.
       for (const marker of this.hbondMarkers) {
-        marker.material.emissiveIntensity = 1.5;
-        setTimeout(() => { marker.material.emissiveIntensity = 0.5; }, 400);
+        marker.material.emissiveIntensity = 1.8;
+        setTimeout(() => { marker.material.emissiveIntensity = 0.7; }, 500);
       }
     }
   }

--- a/src/scenes/TutorialScene.js
+++ b/src/scenes/TutorialScene.js
@@ -66,9 +66,10 @@ export default class TutorialScene {
     this._buildArrow();
     this._buildFloorDecor();
     this._enterState(STATES.INTRO);
-    // Spawn ~1m from the pocket (which sits at z=-0.6) so the user can
-    // interact without walking.
-    this.spawn = { player: [0, 0, 0], camera: [0, 1.6, 0.4] };
+    // Pocket sits at (0, 1.0, -0.6) with radius 0.25 m. Spawn farther
+    // back so the pocket fills a comfortable angular size and the user
+    // isn't physically inside it.
+    this.spawn = { player: [0, 0, 0.8], camera: [0, 1.6, 1.2] };
   }
 
   update(dt, controllers) {

--- a/src/ui/narrative-panel.js
+++ b/src/ui/narrative-panel.js
@@ -187,12 +187,16 @@ export function buildNarrativePanel({
     const autoDismissMs = (narrative.brief?.auto_dismiss_seconds ?? 15) * 1000;
     if (dtSinceBoot >= autoDismissMs) brief.visible = false;
     if (camera) {
-      brief.lookAt(camera.position);
-      if (hint) hint.lookAt(camera.position);
-      // Side-notes are small enough that fixed orientation is fine; if needed,
-      // wrap them in a billboarded child here.
+      // Only billboard `brief` if it's still living inside our group (i.e.
+      // world-locked). Callers that detach `brief` and reparent it onto the
+      // camera (HUD bundle) face the camera by virtue of being a child of
+      // it; calling lookAt against the parent camera misorients it.
+      if (brief.parent === group) brief.lookAt(camera.position);
+      if (hint && hint.parent === group) hint.lookAt(camera.position);
     }
   }
 
-  return { group, dismissBrief, update };
+  // Expose the inner meshes so callers can detach + reparent them (e.g. into
+  // a HUD bundle) without losing the dismiss / billboard contract.
+  return { group, brief, hint, dismissBrief, update };
 }

--- a/src/ui/narrative-panel.js
+++ b/src/ui/narrative-panel.js
@@ -182,13 +182,15 @@ export function buildNarrativePanel({
     brief.visible = false;
   }
 
+  function toggleBrief() {
+    brief.visible = !brief.visible;
+  }
+
   function update(dtMs, camera) {
     dtSinceBoot += dtMs;
-    // 15 s used to be the default; users complained the brief vanished
-    // mid-onboarding. Default 600 s now (effectively manual-dismiss only)
-    // unless the narrative.json explicitly sets a shorter value.
-    const autoDismissMs = (narrative.brief?.auto_dismiss_seconds ?? 600) * 1000;
-    if (dtSinceBoot >= autoDismissMs) brief.visible = false;
+    // Auto-dismiss removed entirely: users complained the brief vanished
+    // mid-onboarding with no way to recall it. Manual-only via A button
+    // (callers can still call dismissBrief/toggleBrief explicitly).
     if (camera) {
       // Only billboard `brief` if it's still living inside our group (i.e.
       // world-locked). Callers that detach `brief` and reparent it onto the
@@ -201,5 +203,5 @@ export function buildNarrativePanel({
 
   // Expose the inner meshes so callers can detach + reparent them (e.g. into
   // a HUD bundle) without losing the dismiss / billboard contract.
-  return { group, brief, hint, dismissBrief, update };
+  return { group, brief, hint, dismissBrief, toggleBrief, update };
 }

--- a/src/ui/narrative-panel.js
+++ b/src/ui/narrative-panel.js
@@ -184,7 +184,10 @@ export function buildNarrativePanel({
 
   function update(dtMs, camera) {
     dtSinceBoot += dtMs;
-    const autoDismissMs = (narrative.brief?.auto_dismiss_seconds ?? 15) * 1000;
+    // 15 s used to be the default; users complained the brief vanished
+    // mid-onboarding. Default 600 s now (effectively manual-dismiss only)
+    // unless the narrative.json explicitly sets a shorter value.
+    const autoDismissMs = (narrative.brief?.auto_dismiss_seconds ?? 600) * 1000;
     if (dtSinceBoot >= autoDismissMs) brief.visible = false;
     if (camera) {
       // Only billboard `brief` if it's still living inside our group (i.e.


### PR DESCRIPTION
## Summary

Hackathon-scope rewrite of the Tutorial → L1 → L2 user flow, plus VR-correct
HUD panels and a number of bug-fixes for transitions, input snapshots, and
scene cleanup. Branched from \`main\` after PR #38 (the \`window.rAF\`-paused-
in-VR fade fix) merged.

L3 is cut from the MVP scope — see the L2-completion + hub-menu commits.

Manually verified end-to-end on Quest 3S: pre-survey → hub → Tutorial →
back to hub → L1 → back to hub → L2 → manual return → L1/L2 ✓ in the
hub menu.

## Changes by area

### Tutorial
* Ghost-overlay UX replacing the alignment-arms-to-markers + magnetic-pull
  scoring. A semi-transparent green ligand ghost sits at the docked pose;
  the user just has to overlay their held copy onto it.
* Progression unblocked for thumbstick-only / mid-drag-release flows: the
  WAIT_SNAP state no longer kicks back to WAIT_GRAB on release, and
  WAIT_GRAB auto-advances after 5 s so a thumbstick-only user isn't stuck.
* Spawn pushed back so the pocket fills a comfortable angular size.

### L1 (COX-2 dock)
* PIVOT_SCALE 1.0 → 0.015 with single-hand grip = 6-DOF translate + rotate
  (rotation gain 2.5×, translation gain 2.0×) and bimanual grip = scale +
  pan (clamped 0.005–0.20). Same gestures across all levels.
* Score readout + dismissible task brief bundled into a single HUD group
  on the camera (top-left), with \`depthTest = false\` so the protein
  never occludes them. Toggle the brief with left-A; no auto-dismiss.
* Target ghost ligand at the Vina best-pose (cloned from the loaded
  ligand GLB, recoloured green, opacity 0.45).
* Big "PERFECT DOCK!" HUD success card on best-pose. Card fades in,
  holds, fades out (3.2 s) and \`onComplete\` fires → \`markProgress\` +
  \`transitionToHub\`.
* Pass conditions: strict best-pose OR relaxed best-pose (distance × 1.30
  with strict H-bond count) OR composite \`result.total ≥ 0.70\`.
* Ligand spawn 0.6 → 50 Å so it doesn't overlap the protein hull at start.
* Protein blue (\`#88aaff\`, surface 0.55 opacity), ligand bright green
  (\`#4ae87a\`).
* Bimanual scale now also rescales the held ligand so protein and
  ligand zoom together.
* Held ligand is detached from controller in \`destroy()\` so it doesn't
  persist into the next scene.

### L2 (rank 5 NSAIDs against COX-2) — full rewrite
The previous L2 was a "click pedestal → reveal pre-baked Vina kcal" quiz
which didn't match the F-005 acceptance criteria. Rebuilt from the L1
architecture:

* Real COX-2 surface + cartoon meshes in a scaled pivot (same grip
  gestures as L1).
* Five real NSAID GLBs (celecoxib, rofecoxib, diclofenac, naproxen,
  ibuprofen) on coloured pedestals fanned out in front of the user;
  each is trigger-grabbable. Pedestal arc anchored at z = +0.50 so it
  sits clear of the protein's bounding hull.
* Glowing translucent green pocket sphere at the active site marks the
  drop zone. Distance-based dock detection: ligand world-position →
  pivot-local Å → less than \`DOCK_TOLERANCE = 6 Å\` triggers a dock.
* Dock event: ligand returns to its pedestal as a green non-grabbable
  marker; pedestal ring re-tints green; bar chart for that ligand
  pops up to its Vina ground-truth ΔG (no animation — \`window.rAF\`
  is paused in immersive-VR sessions on Quest, so the previous
  rAF-driven fill never reached its terminal state and the ΔG label
  stayed hidden); haptic burst.
* HUD bundle = camera-child progress card ("Rank the NSAIDs", "Docked
  N / 5", currently-held ligand name) + dismissible brief, identical
  pattern to L1.
* When all 5 are docked, "ALL FIVE DOCKED!" success card fades in/out
  (3.3 s) and a persistent "Pull TRIGGER to return" prompt appears.
  No auto-transition — the user dismisses on their own (any trigger
  pull while \`completed\` calls \`onComplete\` via the same
  \`_onControllerClick\` contract \`GameHubScene\` uses).

### Hub
* Trigger click defers raycast to the next \`update()\` and uses the
  pre-computed \`hoveredRow\` (raycast on fresh matrices in
  \`_updateHover\`) — fixes the "hover lights up but click does nothing"
  matrix-stale race when the WebXR \`selectstart\` event fires off the
  XR-frame timeline.
* L3 row dropped from \`LEVEL_DEFS\`; \`UNLOCK_ORDER\` shortened to
  \`[tutorial, l1, l2]\`.

### main.js
* \`SCENE_MAP.l2\` now points to \`LevelTwoScene\` (was \`null\`).
  \`SCENE_MAP.l3\` removed; \`LevelThreeScene\` import gone.
* \`transitionToScene\` / \`transitionToHub\` wrapped in try/finally so a
  thrown error in load/fade can never leave \`transitioning = true\`
  permanently and pin the user on a dead screen.
* Player thumbstick locomotion replaced with a \`handleThumbstickInput\`
  forwarder that delegates to the active scene's \`applyThumbstickInput\`
  (per the educational-scene rule in
  \`.omc/wiki/webxr-locomotion-comfort.md\`: disable smooth-locomotion).

### Visual polish
* Ligand surface 1.0 → 0.55 opacity in both L1 and L2, with a
  \`THREE.EdgesGeometry\` line overlay (20° crease threshold) on every
  mesh — composite reads as ball+stick without re-exporting from PyMOL.

### narrative-panel.js
* Returns \`brief\` and \`hint\` mesh references so callers can detach
  and reparent (used to bundle the brief into the HUD).
* \`update()\` skips its \`lookAt\` when a mesh is no longer a child of
  the panel group (prevents weird HUD orientation when re-parented to
  the camera).
* Auto-dismiss timer removed entirely; \`toggleBrief()\` exposed for
  manual show/hide.

## Test plan

- [x] \`npx vitest run\` — 9/9 \`scoring\` tests pass.
- [x] Manual on Quest 3S: pre-survey → hub → Tutorial → hub → L1 → hub →
  L2 (all 5 ligands) → return prompt → trigger → hub. Verified.
- [ ] Desktop fallback for any tester not on a headset (mouse-click
  dock, WASD locked off — locomotion is intentionally disabled).

## Out of scope (queued, not in this PR)

- L1 clash haptic + red flash (#37)
- L1 contextual hint when ligand grabbed (#40)
- L1 magnetic snap when score > 0.9 (#41)
- L3 (cut from MVP)
- Centralized \`handleSelectStart\` hook contract (#34)
- AudioContext.resume + setPixelRatio cap + foveation (#36)

## Changelog

### Added
- Tutorial ghost-overlay UX: drop the held ligand onto a green ghost to dock; manual A-button toggle. Player-locked + thumbstick-routes-to-scene-object pattern. L1 / L2 6-DOF grip with bimanual scale + pan. L1 target ghost at Vina best-pose. L1 / L2 HUD bundle (score / progress + dismissible brief, depth-tested off). L1 dock-success card + auto-transition. L2 full rewrite: dock 5 NSAIDs into COX-2, bar chart fills with Vina ΔG. L1 / L2 ball+stick reading via translucent surface + EdgesGeometry overlay.
### Fixed
- Hub trigger-click matrix-stale race. \`_animateFade\` race in immersive-VR (via the now-merged PR #38). L1 grabbed-ligand persisting into next scene. L2 bar ΔG never appearing because the rAF-driven fill animation never completed in VR. Brief auto-dismiss vanishing mid-onboarding. \`SCENE_MAP.l2\` not registering \`LevelTwoScene\`. \`onComplete\` not wired on L1 (constructor missing the field).
### Removed
- Player thumbstick locomotion (replaced with scene-routed thumbstick input). L3 from the MVP scope (Hub menu + SCENE_MAP).