### PR TITLE
level1_sitefix

### DIFF
--- a/src/lib/scoring.js
+++ b/src/lib/scoring.js
@@ -5,7 +5,11 @@
 // THREE.Vector3 (both expose .x/.y/.z); operates only on those numbers.
 
 export const DEFAULT_WEIGHTS = { alpha: 0.6, beta: 0.3, gamma: 0.1 };
-export const DEFAULT_THRESHOLDS = { hBondDist: 3.5, clashDist: 1.0, dMax: 10.0 };
+// `contactDist` gates the whole score: if no ligand atom is within this many Å
+// of any key-residue side-chain centroid, the ligand is considered "not
+// attached" and total = 0 (otherwise the distance term alone gives credit
+// just for being roughly near the ideal docked centroid).
+export const DEFAULT_THRESHOLDS = { hBondDist: 3.5, clashDist: 1.0, dMax: 10.0, contactDist: 5.0 };
 export const BEST_POSE = { distance: 3.0, hBondHits: 2 };
 
 const HBOND_ROLES = new Set(['h_bond_donor', 'h_bond_acceptor']);
@@ -59,6 +63,7 @@ export function computeScore({
 
   let hBondHits = 0;
   let clashes = 0;
+  let minNearestAtomDist = Infinity;
   const residues = pocketAnnotation.key_residues || [];
 
   for (const residue of residues) {
@@ -71,15 +76,22 @@ export function computeScore({
       if (d < thresholds.clashDist) clashes += 1;
     }
 
+    if (nearestAtomDist < minNearestAtomDist) minNearestAtomDist = nearestAtomDist;
+
     if (HBOND_ROLES.has(residue.role) && nearestAtomDist < thresholds.hBondDist) {
       hBondHits += 1;
     }
   }
 
-  const total =
-    weights.alpha * distanceTerm +
-    weights.beta * hBondHits -
-    weights.gamma * clashes;
+  // Contact gate: if no ligand atom is within `contactDist` of any pocket
+  // residue, the ligand isn't actually touching the protein → score = 0.
+  // Prevents the distance-to-best-pose term from awarding credit just for
+  // being roughly near the ideal centroid in space.
+  const isAttached = minNearestAtomDist < thresholds.contactDist;
+
+  const total = isAttached
+    ? weights.alpha * distanceTerm + weights.beta * hBondHits - weights.gamma * clashes
+    : 0;
 
   const isBestPose =
     rawDistance < BEST_POSE.distance && hBondHits >= BEST_POSE.hBondHits;

--- a/src/scenes/LevelOneScene.js
+++ b/src/scenes/LevelOneScene.js
@@ -219,6 +219,11 @@ export default class LevelOneScene {
     // Build pivot — the centre of all scene objects
     const pivot = new THREE.Group();
     pivot.position.set(0, 1.0, -0.8);
+    // PDB geometry is in Å — without PIVOT_SCALE a 5 nm protein renders 50 m
+    // wide and the user spawns inside the molecule. Procedural fallbacks are
+    // already authored in world units, so only scale down when a real GLB
+    // loaded.
+    if (cox2Surface || cox2Cartoon) pivot.scale.setScalar(PIVOT_SCALE);
     this.ctx.scene.add(pivot);
     this.objects.push(pivot);
     this._uiWorldAnchor.copy(pivot.position);
@@ -251,7 +256,18 @@ export default class LevelOneScene {
     } else {
       // Procedural fallback: a small dodecahedron for celecoxib
       const fallbackLigand = createLigand();
-      fallbackLigand.position.copy(SPAWN_OFFSET);
+      // SPAWN_OFFSET (0.6) is in Å for the GLB path (≈9 mm after PIVOT_SCALE).
+      // The procedural protein is unscaled (~0.6 m radius), so use a much
+      // larger world-unit offset and bump the ligand size for visibility from
+      // the new spawn distance (~9 m away).
+      fallbackLigand.position.set(2.5, 0, 0);
+      fallbackLigand.scale.setScalar(5.0);
+      fallbackLigand.traverse?.((c) => {
+        if (c.material?.emissive) {
+          c.material.emissive.setHex(0xffaa33);
+          c.material.emissiveIntensity = 1.4;
+        }
+      });
       fallbackLigand.userData.grabbable = true;
       pivot.add(fallbackLigand);
       this.ligand = fallbackLigand;
@@ -331,8 +347,10 @@ export default class LevelOneScene {
     this._buildSuccessCard();
 
     this.pivot = pivot;
-    // Spawn even farther so the user starts with a full view of the protein.
-    this.spawn = { player: [0, 0, 1.5], camera: [0, 1.6, 2.2] };
+    // Spawn far enough back that the player starts well clear of the protein
+    // hull — the procedural fallback (no PIVOT_SCALE) is ~1 m diameter at
+    // pivot z=-0.8, so push the player back to z=5 to keep ≥ 5 m clearance.
+    this.spawn = { player: [0, 0, 5.0], camera: [0, 1.6, 3.0] };
     this.ready = true;
 
     // Snapshot current A/B state so a held button doesn't produce a phantom


### PR DESCRIPTION
<!--
The leader agent reads this PR body. Sections marked REQUIRED must be filled
or the leader will request changes and refuse to merge.
-->

Closes #<!-- issue number, REQUIRED -->

## What & why

<!-- Short prose. What does this change do, and why now? -->

## Testing

<!-- What did you run? What did you check by hand? -->

## Changelog

<!--
REQUIRED. One Keep-a-Changelog line, prefixed with the section name.
The leader appends this to CHANGELOG.md on `main` after merge.
Examples:
  Added: rotation gizmo on the structure viewer
  Fixed: chain selection now persists when re-loading the same PDB
  Changed: PDB ingestion pipeline switched to streaming parse
-->

Added:

---

<!--
Optional opt-ins for the leader:
- Add the `leader:auto-merge` label if you want the leader to merge alone (still requires all required CI checks to pass).
- Add the `leader:hold` label if you want the leader to comment but never merge (e.g. you want a manual merge).
-->
